### PR TITLE
merge existing go-text/ repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# typesetting
+
+This typesetting library is shared by multiple Go UI toolkits including Fyne, and GIO.

--- a/di/direction.go
+++ b/di/direction.go
@@ -1,0 +1,10 @@
+package di
+
+type Direction int
+
+const (
+	DirectionLTR Direction = iota
+	DirectionRTL
+
+// Could add Top-to-Bottom (TTB) and Bottom-to-Top (BTT) in future.
+)

--- a/font/face.go
+++ b/font/face.go
@@ -1,0 +1,14 @@
+package font
+
+import "github.com/benoitkugler/textlayout/fonts"
+
+// make sure that we can use textlayout/fonts.Face as Face
+var _ Face = (fonts.Face)(nil)
+
+type GID = fonts.GID
+
+type Face interface {
+	// NominalGlyph returns the glyph identifier used to represent the given rune,
+	// or false the rune is not supported by the font.
+	NominalGlyph(r rune) (GID, bool)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/go-text/typesetting
+
+go 1.16
+
+require (
+	github.com/benoitkugler/textlayout v0.0.3
+	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,14 @@
+github.com/benoitkugler/pstokenizer v1.0.0/go.mod h1:l1G2Voirz0q/jj0TQfabNxVsa8HZXh/VMxFSRALWTiE=
+github.com/benoitkugler/textlayout v0.0.3 h1:r/PmSx9+MoFr0JkJjWu9XeU04caWg6pzqSGLXzkrdHY=
+github.com/benoitkugler/textlayout v0.0.3/go.mod h1:puH4v13Uz7uIhIH0XMk5jgc8U3MXcn5r3VlV9K8n0D8=
+golang.org/x/image v0.0.0-20210504121937-7319ad40d33e/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
+golang.org/x/image v0.0.0-20211028202545-6944b10bf410 h1:hTftEOvwiOq2+O8k2D5/Q7COC7k5Qcrgc2TFURJYnvQ=
+golang.org/x/image v0.0.0-20211028202545-6944b10bf410/go.mod h1:023OzeP/+EPmXeapQh35lcL3II3LrY8Ic+EFFKVhULM=
+golang.org/x/net v0.0.0-20210510120150-4163338589ed/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/text v0.3.6 h1:aRYxNxv6iGQlyVaZmk6ZgYEDa+Jg18DxebPSrd6bg1M=
+golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/shaping/input.go
+++ b/shaping/input.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Unlicense OR BSD-3-Clause
+
+package shaping
+
+import (
+	"github.com/benoitkugler/textlayout/language"
+	"github.com/go-text/typesetting/di"
+	"github.com/go-text/typesetting/font"
+	"golang.org/x/image/math/fixed"
+)
+
+type Input struct {
+	// Text is the body of text being shaped. Only the range Text[RunStart:RunEnd] is considered
+	// for shaping, with the rest provided as context for the shaper. This helps with, for example,
+	// cross-run Arabic shaping or handling combining marks at the start of a run.
+	Text []rune
+	// RunStart and RunEnd indicate the subslice of Text being shaped.
+	RunStart, RunEnd int
+	// Direction is the directionality of the text.
+	Direction di.Direction
+	// Face is the font face to render the text in.
+	Face font.Face
+
+	// Size is the requested size of the font.
+	// More generally, it is a scale factor applied to the resulting metrics.
+	// For instance, given a device resolution (in dpi) and a point size (like 14), the `Size` to
+	// get result in pixels is given by : pointSize * dpi / 72
+	Size fixed.Int26_6
+
+	// Script is an identifier for the writing system used in the text.
+	Script language.Script
+
+	// Language is an identifier for the language of the text.
+	Language language.Language
+}

--- a/shaping/output.go
+++ b/shaping/output.go
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: Unlicense OR BSD-3-Clause
+
+package shaping
+
+import (
+	"fmt"
+
+	"github.com/benoitkugler/textlayout/fonts"
+	"github.com/benoitkugler/textlayout/harfbuzz"
+	"github.com/go-text/typesetting/di"
+	"golang.org/x/image/math/fixed"
+)
+
+// Glyph describes the attributes of a single glyph from a single
+// font face in a shaped output.
+type Glyph struct {
+	Width    fixed.Int26_6
+	Height   fixed.Int26_6
+	XBearing fixed.Int26_6
+	YBearing fixed.Int26_6
+	XAdvance fixed.Int26_6
+	YAdvance fixed.Int26_6
+	XOffset  fixed.Int26_6
+	YOffset  fixed.Int26_6
+	// ClusterIndex is the lowest rune index of all runes shaped into
+	// this glyph cluster. All glyphs sharing the same cluster value
+	// are part of the same cluster and will have identical RuneCount
+	// and GlyphCount fields.
+	ClusterIndex int
+	// RuneCount is the number of input runes shaped into this output
+	// glyph cluster.
+	RuneCount int
+	// GlyphCount is the number of glyphs in this output glyph cluster.
+	GlyphCount int
+	GlyphID    fonts.GID
+	Mask       harfbuzz.GlyphMask
+}
+
+// LeftSideBearing returns the distance from the glyph's X origin to
+// its leftmost edge. This value can be negative if the glyph extends
+// across the origin.
+func (g Glyph) LeftSideBearing() fixed.Int26_6 {
+	return g.XBearing
+}
+
+// RightSideBearing returns the distance from the glyph's right edge to
+// the edge of the glyph's advance. This value can be negative if the glyph's
+// right edge is before the end of its advance.
+func (g Glyph) RightSideBearing() fixed.Int26_6 {
+	return g.XAdvance - g.Width - g.XBearing
+}
+
+// Bounds describes the minor-axis bounds of a line of text. In a LTR or RTL
+// layout, it describes the vertical axis. In a BTT or TTB layout, it describes
+// the horizontal.
+//
+// For horizontal text:
+//
+//     - Ascent      GLYPH
+//     |             GLYPH
+//     |             GLYPH
+//     |             GLYPH
+//     |             GLYPH
+//     - Baseline    GLYPH
+//     |             GLYPH
+//     |             GLYPH
+//     |             GLYPH
+//     - Descent     GLYPH
+//     |
+//     - Gap
+type Bounds struct {
+	// Ascent is the maximum ascent away from the baseline. This value is typically
+	// positive in coordiate systems that grow up.
+	Ascent fixed.Int26_6
+	// Descent is the maximum descent away from the baseline. This value is typically
+	// negative in coordinate systems that grow up.
+	Descent fixed.Int26_6
+	// Gap is the height of empty pixels between lines. This value is typically positive
+	// in coordinate systems that grow up.
+	Gap fixed.Int26_6
+}
+
+// LineHeight returns the height of a horizontal line of text described by b.
+func (b Bounds) LineHeight() fixed.Int26_6 {
+	return b.Ascent - b.Descent + b.Gap
+}
+
+// Output describes the dimensions and content of shaped text.
+type Output struct {
+	// Advance is the distance the Dot has advanced.
+	Advance fixed.Int26_6
+	// Glyphs are the shaped output text.
+	Glyphs []Glyph
+	// LineBounds describes the font's suggested line bounding dimensions. The
+	// dimensions described should contain any glyphs from the given font.
+	LineBounds Bounds
+	// GlyphBounds describes a tight bounding box on the specific glyphs contained
+	// within this output. The dimensions may not be sufficient to contain all
+	// glyphs within the chosen font.
+	GlyphBounds Bounds
+}
+
+// UnimplementedDirectionError is returned when a function does not support the
+// provided layout direction yet.
+type UnimplementedDirectionError struct {
+	Direction di.Direction
+}
+
+// Error formats the error into a string message.
+func (u UnimplementedDirectionError) Error() string {
+	return fmt.Sprintf("support for text direction %v is not implemented yet", u.Direction)
+}
+
+// RecomputeAdvance updates only the Advance field based on the current
+// contents of the Glyphs field. It is faster than RecalculateAll(),
+// and can be used to speed up line wrapping logic.
+func (o *Output) RecomputeAdvance(dir di.Direction) {
+	advance := fixed.Int26_6(0)
+	switch dir {
+	case di.DirectionLTR, di.DirectionRTL:
+		for _, g := range o.Glyphs {
+			advance += g.XAdvance
+		}
+	default: // vertical
+		for _, g := range o.Glyphs {
+			advance += g.YAdvance
+		}
+	}
+	o.Advance = advance
+}
+
+// RecalculateAll updates the all other fields of the Output
+// to match the current contents of the Glyphs field.
+// This method will fail with UnimplementedDirectionError if the provided
+// direction is unimplemented.
+func (o *Output) RecalculateAll(dir di.Direction) error {
+	var (
+		advance fixed.Int26_6
+		tallest fixed.Int26_6
+		lowest  fixed.Int26_6
+	)
+
+	switch dir {
+	default:
+		return UnimplementedDirectionError{Direction: dir}
+	case di.DirectionLTR, di.DirectionRTL:
+		for i := range o.Glyphs {
+			g := &o.Glyphs[i]
+			advance += g.XAdvance
+			height := g.YBearing + g.YOffset
+			if height > tallest {
+				tallest = height
+			}
+			depth := height + g.Height
+			if depth < lowest {
+				lowest = depth
+			}
+		}
+	}
+	o.Advance = advance
+	o.GlyphBounds = Bounds{
+		Ascent:  tallest,
+		Descent: lowest,
+	}
+
+	return nil
+}

--- a/shaping/output_test.go
+++ b/shaping/output_test.go
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: Unlicense OR BSD-3-Clause
+
+package shaping_test
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/benoitkugler/textlayout/fonts"
+	"github.com/benoitkugler/textlayout/harfbuzz"
+	"github.com/go-text/typesetting/di"
+	"github.com/go-text/typesetting/shaping"
+	"golang.org/x/image/math/fixed"
+)
+
+const (
+	simpleGID fonts.GID = iota
+	leftExtentGID
+	rightExtentGID
+	deepGID
+	offsetGID
+)
+
+var (
+	expectedFontExtents = shaping.Bounds{
+		Ascent:  fixed.I(int(15)),
+		Descent: fixed.I(int(-15)),
+		Gap:     fixed.I(int(0)),
+	}
+	simpleGlyph = shaping.Glyph{
+		GlyphID:  simpleGID,
+		XAdvance: fixed.I(int(10)),
+		YAdvance: fixed.I(int(10)),
+		XOffset:  fixed.I(int(0)),
+		YOffset:  fixed.I(int(0)),
+		Width:    fixed.I(int(10)),
+		Height:   -fixed.I(int(10)),
+		YBearing: fixed.I(int(10)),
+	}
+	leftExtentGlyph = shaping.Glyph{
+		GlyphID:  leftExtentGID,
+		XAdvance: fixed.I(int(5)),
+		YAdvance: fixed.I(int(5)),
+		XOffset:  fixed.I(int(0)),
+		YOffset:  fixed.I(int(0)),
+		Width:    fixed.I(int(10)),
+		Height:   -fixed.I(int(10)),
+		YBearing: fixed.I(int(10)),
+		XBearing: fixed.I(int(5)),
+	}
+	rightExtentGlyph = shaping.Glyph{
+		GlyphID:  rightExtentGID,
+		XAdvance: fixed.I(int(5)),
+		YAdvance: fixed.I(int(5)),
+		XOffset:  fixed.I(int(0)),
+		YOffset:  fixed.I(int(0)),
+		Width:    fixed.I(int(10)),
+		Height:   -fixed.I(int(10)),
+		YBearing: fixed.I(int(10)),
+		XBearing: fixed.I(int(0)),
+	}
+	deepGlyph = shaping.Glyph{
+		GlyphID:  deepGID,
+		XAdvance: fixed.I(int(10)),
+		YAdvance: fixed.I(int(10)),
+		XOffset:  fixed.I(int(0)),
+		YOffset:  fixed.I(int(0)),
+		Width:    fixed.I(int(10)),
+		Height:   -fixed.I(int(10)),
+		YBearing: fixed.I(int(0)),
+		XBearing: fixed.I(int(0)),
+	}
+	offsetGlyph = shaping.Glyph{
+		GlyphID:  offsetGID,
+		XAdvance: fixed.I(int(10)),
+		YAdvance: fixed.I(int(10)),
+		XOffset:  fixed.I(int(2)),
+		YOffset:  fixed.I(int(2)),
+		Width:    fixed.I(int(10)),
+		Height:   -fixed.I(int(10)),
+		YBearing: fixed.I(int(10)),
+		XBearing: fixed.I(int(0)),
+	}
+)
+
+// TestRecalculate ensures that the Output.Recalculate function correctly
+// computes the bounds, advance, and baseline of the output.
+func TestRecalculate(t *testing.T) {
+	type testcase struct {
+		Name      string
+		Direction di.Direction
+		Input     []shaping.Glyph
+		Output    shaping.Output
+		Error     error
+	}
+	for _, tc := range []testcase{
+		{
+			Name: "empty",
+			Output: shaping.Output{
+				LineBounds: expectedFontExtents,
+			},
+		},
+		{
+			Name:      "single simple glyph",
+			Direction: di.DirectionLTR,
+			Input:     []shaping.Glyph{simpleGlyph},
+			Output: shaping.Output{
+				Glyphs:  []shaping.Glyph{simpleGlyph},
+				Advance: simpleGlyph.XAdvance,
+				GlyphBounds: shaping.Bounds{
+					Ascent:  simpleGlyph.YBearing,
+					Descent: fixed.I(0),
+				},
+				LineBounds: expectedFontExtents,
+			},
+		},
+		{
+			Name:      "glyph below baseline",
+			Direction: di.DirectionLTR,
+			Input:     []shaping.Glyph{simpleGlyph, deepGlyph},
+			Output: shaping.Output{
+				Glyphs:  []shaping.Glyph{simpleGlyph, deepGlyph},
+				Advance: simpleGlyph.XAdvance + deepGlyph.XAdvance,
+				GlyphBounds: shaping.Bounds{
+					Ascent:  simpleGlyph.YBearing,
+					Descent: deepGlyph.YBearing + deepGlyph.Height,
+				},
+				LineBounds: expectedFontExtents,
+			},
+		},
+		{
+			Name:      "single complex glyph",
+			Direction: di.DirectionLTR,
+			Input:     []shaping.Glyph{offsetGlyph},
+			Output: shaping.Output{
+				Glyphs:  []shaping.Glyph{offsetGlyph},
+				Advance: offsetGlyph.XAdvance,
+				GlyphBounds: shaping.Bounds{
+					Ascent:  offsetGlyph.YBearing + offsetGlyph.YOffset,
+					Descent: fixed.I(0),
+				},
+				LineBounds: expectedFontExtents,
+			},
+		},
+		{
+			Name:      "vertical text not supported",
+			Direction: di.Direction(harfbuzz.BottomToTop),
+			Error:     shaping.UnimplementedDirectionError{},
+		},
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			output := shaping.Output{
+				Glyphs:     tc.Input,
+				LineBounds: expectedFontExtents,
+			}
+			err := output.RecalculateAll(tc.Direction)
+			if tc.Error != nil && !errors.As(err, &tc.Error) {
+				t.Errorf("expected error of type %T, got %T", tc.Error, err)
+			} else if tc.Error == nil && !reflect.DeepEqual(output, tc.Output) {
+				t.Errorf("recalculation incorrect: expected %v, got %v", tc.Output, output)
+			}
+		})
+	}
+}

--- a/shaping/shaper.go
+++ b/shaping/shaper.go
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: Unlicense OR BSD-3-Clause
+
+package shaping
+
+import (
+	"fmt"
+
+	"github.com/benoitkugler/textlayout/fonts"
+	"github.com/benoitkugler/textlayout/harfbuzz"
+	"github.com/go-text/typesetting/di"
+	"golang.org/x/image/math/fixed"
+)
+
+type Shaper interface {
+	// Shape takes an Input and shapes it into the Output.
+	Shape(Input) Output
+}
+
+// MissingGlyphError indicates that the font used in shaping did not
+// have a glyph needed to complete the shaping.
+type MissingGlyphError struct {
+	fonts.GID
+}
+
+func (m MissingGlyphError) Error() string {
+	return fmt.Sprintf("missing glyph with id %d", m.GID)
+}
+
+// InvalidRunError represents an invalid run of text, either because
+// the end is before the start or because start or end is greater
+// than the length.
+type InvalidRunError struct {
+	RunStart, RunEnd, TextLength int
+}
+
+func (i InvalidRunError) Error() string {
+	return fmt.Sprintf("run from %d to %d is not valid for text len %d", i.RunStart, i.RunEnd, i.TextLength)
+}
+
+const (
+	// scaleShift is the power of 2 with which to automatically scale
+	// up the input coordinate space of the shaper. This factor will
+	// be removed prior to returning dimensions. This ensures that the
+	// returned glyph dimensions take advantage of all of the precision
+	// that a fixed.Int26_6 can provide.
+	scaleShift = 6
+)
+
+// Shape turns an input into an output.
+func Shape(input Input) (Output, error) {
+	// Prepare to shape the text.
+	// TODO: maybe reuse these buffers for performance?
+	buf := harfbuzz.NewBuffer()
+	runes, start, end := input.Text, input.RunStart, input.RunEnd
+	if end < start {
+		return Output{}, InvalidRunError{RunStart: start, RunEnd: end, TextLength: len(input.Text)}
+	}
+	buf.AddRunes(runes, start, end-start)
+	// TODO: handle vertical text?
+	switch input.Direction {
+	case di.DirectionLTR:
+		buf.Props.Direction = harfbuzz.LeftToRight
+	case di.DirectionRTL:
+		buf.Props.Direction = harfbuzz.RightToLeft
+	default:
+		return Output{}, UnimplementedDirectionError{
+			Direction: input.Direction,
+		}
+	}
+	buf.Props.Language = input.Language
+	buf.Props.Script = input.Script
+	// TODO: figure out what (if anything) to do if this type assertion fails.
+	font := harfbuzz.NewFont(input.Face.(harfbuzz.Face))
+	font.XScale = int32(input.Size.Ceil()) << scaleShift
+	font.YScale = font.XScale
+
+	// Actually use harfbuzz to shape the text.
+	buf.Shape(font, nil)
+
+	// Convert the shaped text into an Output.
+	glyphs := make([]Glyph, len(buf.Info))
+	for i := range glyphs {
+		g := buf.Info[i].Glyph
+		extents, ok := font.GlyphExtents(g)
+		if !ok {
+			// TODO: can this error happen? Will harfbuzz return a
+			// GID for a glyph that isn't in the font?
+			return Output{}, MissingGlyphError{GID: g}
+		}
+		glyphs[i] = Glyph{
+			Width:        fixed.I(int(extents.Width)) >> scaleShift,
+			Height:       fixed.I(int(extents.Height)) >> scaleShift,
+			XBearing:     fixed.I(int(extents.XBearing)) >> scaleShift,
+			YBearing:     fixed.I(int(extents.YBearing)) >> scaleShift,
+			XAdvance:     fixed.I(int(buf.Pos[i].XAdvance)) >> scaleShift,
+			YAdvance:     fixed.I(int(buf.Pos[i].YAdvance)) >> scaleShift,
+			XOffset:      fixed.I(int(buf.Pos[i].XOffset)) >> scaleShift,
+			YOffset:      fixed.I(int(buf.Pos[i].YOffset)) >> scaleShift,
+			ClusterIndex: buf.Info[i].Cluster,
+			GlyphID:      g,
+			Mask:         buf.Info[i].Mask,
+		}
+	}
+	countClusters(glyphs, input.RunEnd-input.RunStart, input.Direction)
+	out := Output{
+		Glyphs: glyphs,
+	}
+	fontExtents := font.ExtentsForDirection(buf.Props.Direction)
+	out.LineBounds = Bounds{
+		Ascent:  fixed.I(int(fontExtents.Ascender)) >> scaleShift,
+		Descent: fixed.I(int(fontExtents.Descender)) >> scaleShift,
+		Gap:     fixed.I(int(fontExtents.LineGap)) >> scaleShift,
+	}
+	return out, out.RecalculateAll(input.Direction)
+}
+
+// countClusters tallies the number of runes and glyphs in each cluster
+// and updates the relevant fields on the provided glyph slice.
+func countClusters(glyphs []Glyph, textLen int, dir di.Direction) {
+	currentCluster := -1
+	runesInCluster := 0
+	glyphsInCluster := 0
+	previousCluster := textLen
+	for i := range glyphs {
+		g := glyphs[i].ClusterIndex
+		if g != currentCluster {
+			// If we're processing a new cluster, count the runes and glyphs
+			// that compose it.
+			runesInCluster = 0
+			glyphsInCluster = 1
+			currentCluster = g
+			nextCluster := -1
+		glyphCountLoop:
+			for k := i + 1; k < len(glyphs); k++ {
+				if glyphs[k].ClusterIndex == g {
+					glyphsInCluster++
+				} else {
+					nextCluster = glyphs[k].ClusterIndex
+					break glyphCountLoop
+				}
+			}
+			if nextCluster == -1 {
+				nextCluster = textLen
+			}
+			switch dir {
+			case di.DirectionLTR:
+				runesInCluster = nextCluster - currentCluster
+			case di.DirectionRTL:
+				runesInCluster = previousCluster - currentCluster
+			}
+			previousCluster = g
+		}
+		glyphs[i].GlyphCount = glyphsInCluster
+		glyphs[i].RuneCount = runesInCluster
+	}
+}

--- a/shaping/shaping_test.go
+++ b/shaping/shaping_test.go
@@ -1,0 +1,159 @@
+package shaping
+
+import (
+	"testing"
+
+	"github.com/go-text/typesetting/di"
+)
+
+func TestCountClusters(t *testing.T) {
+	type testcase struct {
+		name     string
+		textLen  int
+		dir      di.Direction
+		glyphs   []Glyph
+		expected []Glyph
+	}
+	for _, tc := range []testcase{
+		{
+			name: "empty",
+		},
+		{
+			name:    "ltr",
+			textLen: 8,
+			dir:     di.DirectionLTR,
+			// Addressing the runes of text as A[0]-A[9] and the glyphs as
+			// G[0]-G[5], this input models the following:
+			// A[0] => G[0]
+			// A[1],A[2] => G[1] (ligature)
+			// A[3] => G[2],G[3] (expansion)
+			// A[4],A[5],A[6],A[7] => G[4],G[5] (reorder, ligature, etc...)
+			glyphs: []Glyph{
+				{
+					ClusterIndex: 0,
+				},
+				{
+					ClusterIndex: 1,
+				},
+				{
+					ClusterIndex: 3,
+				},
+				{
+					ClusterIndex: 3,
+				},
+				{
+					ClusterIndex: 4,
+				},
+				{
+					ClusterIndex: 4,
+				},
+			},
+			expected: []Glyph{
+				{
+					ClusterIndex: 0,
+					RuneCount:    1,
+					GlyphCount:   1,
+				},
+				{
+					ClusterIndex: 1,
+					RuneCount:    2,
+					GlyphCount:   1,
+				},
+				{
+					ClusterIndex: 3,
+					RuneCount:    1,
+					GlyphCount:   2,
+				},
+				{
+					ClusterIndex: 3,
+					RuneCount:    1,
+					GlyphCount:   2,
+				},
+				{
+					ClusterIndex: 4,
+					RuneCount:    4,
+					GlyphCount:   2,
+				},
+				{
+					ClusterIndex: 4,
+					RuneCount:    4,
+					GlyphCount:   2,
+				},
+			},
+		},
+		{
+			name:    "rtl",
+			textLen: 8,
+			dir:     di.DirectionRTL,
+			// Addressing the runes of text as A[0]-A[9] and the glyphs as
+			// G[0]-G[5], this input models the following:
+			// A[0] => G[5]
+			// A[1],A[2] => G[4] (ligature)
+			// A[3] => G[2],G[3] (expansion)
+			// A[4],A[5],A[6],A[7] => G[0],G[1] (reorder, ligature, etc...)
+			glyphs: []Glyph{
+				{
+					ClusterIndex: 4,
+				},
+				{
+					ClusterIndex: 4,
+				},
+				{
+					ClusterIndex: 3,
+				},
+				{
+					ClusterIndex: 3,
+				},
+				{
+					ClusterIndex: 1,
+				},
+				{
+					ClusterIndex: 0,
+				},
+			},
+			expected: []Glyph{
+				{
+					ClusterIndex: 4,
+					RuneCount:    4,
+					GlyphCount:   2,
+				},
+				{
+					ClusterIndex: 4,
+					RuneCount:    4,
+					GlyphCount:   2,
+				},
+				{
+					ClusterIndex: 3,
+					RuneCount:    1,
+					GlyphCount:   2,
+				},
+				{
+					ClusterIndex: 3,
+					RuneCount:    1,
+					GlyphCount:   2,
+				},
+				{
+					ClusterIndex: 1,
+					RuneCount:    2,
+					GlyphCount:   1,
+				},
+				{
+					ClusterIndex: 0,
+					RuneCount:    1,
+					GlyphCount:   1,
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			countClusters(tc.glyphs, tc.textLen, tc.dir)
+			for i := range tc.glyphs {
+				g := tc.glyphs[i]
+				e := tc.expected[i]
+				if !(g.ClusterIndex == e.ClusterIndex && g.RuneCount == e.RuneCount && g.GlyphCount == e.GlyphCount) {
+					t.Errorf("mismatch on glyph %d: expected cluster %d RuneCount %d GlyphCount %d, got cluster %d RuneCount %d GlyphCount %d", i, e.ClusterIndex, e.RuneCount, e.GlyphCount, g.ClusterIndex, g.RuneCount, g.GlyphCount)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Following https://github.com/go-text/shaping/issues/2 and the slack discussion, this PR merges the existing go-text repository in one module.

I took the liberty to include https://github.com/go-text/shaping/pull/11, since it seems accepted (pending @stuartmscott approval)