### PR TITLE
di: define vertical directions and axis helper

### DIFF
--- a/di/direction.go
+++ b/di/direction.go
@@ -1,10 +1,33 @@
 package di
 
-type Direction int
+// Direction indicates the layout direction of a piece of text.
+type Direction uint8
 
 const (
+	// DirectionLTR is for Left-to-Right text.
 	DirectionLTR Direction = iota
+	// DirectionRTL is for Right-to-Left text.
 	DirectionRTL
+	// DirectionTTB is for Top-to-Bottom text.
+	DirectionTTB
+	// DirectionBTT is for Bottom-to-Top text.
+	DirectionBTT
+)
 
-// Could add Top-to-Bottom (TTB) and Bottom-to-Top (BTT) in future.
+// Axis returns the layout axis for d.
+func (d Direction) Axis() Axis {
+	switch d {
+	case DirectionBTT, DirectionTTB:
+		return Vertical
+	default:
+		return Horizontal
+	}
+}
+
+// Axis indicates the axis of layout for a piece of text.
+type Axis uint8
+
+const (
+	Horizontal Axis = iota
+	Vertical
 )

--- a/di/direction.go
+++ b/di/direction.go
@@ -14,8 +14,21 @@ const (
 	DirectionBTT
 )
 
-// Axis returns the layout axis for d.
-func (d Direction) Axis() Axis {
+// IsVertical returns the layout axis for d. The return value can be
+// used as a value of type axis or as a boolean representing
+// whether the text is vertical.
+//
+//     if d.IsVertical() {
+//     } else {
+//         // Must be Horizontal.
+//     }
+//
+//     switch d.IsVertical() {
+//         case Vertical:
+//         case Horzontal:
+//     }
+//
+func (d Direction) IsVertical() Axis {
 	switch d {
 	case DirectionBTT, DirectionTTB:
 		return Vertical
@@ -25,9 +38,9 @@ func (d Direction) Axis() Axis {
 }
 
 // Axis indicates the axis of layout for a piece of text.
-type Axis uint8
+type Axis bool
 
 const (
-	Horizontal Axis = iota
-	Vertical
+	Horizontal Axis = false
+	Vertical   Axis = true
 )

--- a/di/direction.go
+++ b/di/direction.go
@@ -14,21 +14,15 @@ const (
 	DirectionBTT
 )
 
-// IsVertical returns the layout axis for d. The return value can be
-// used as a value of type axis or as a boolean representing
-// whether the text is vertical.
-//
-//     if d.IsVertical() {
-//     } else {
-//         // Must be Horizontal.
-//     }
-//
-//     switch d.IsVertical() {
-//         case Vertical:
-//         case Horzontal:
-//     }
-//
-func (d Direction) IsVertical() Axis {
+// IsVertical returns whether d is laid out on a vertical
+// axis. If the return value is false, d is on the horizontal
+// axis.
+func (d Direction) IsVertical() bool {
+	return d == DirectionBTT || d == DirectionTTB
+}
+
+// Axis returns the layout axis for d.
+func (d Direction) Axis() Axis {
 	switch d {
 	case DirectionBTT, DirectionTTB:
 		return Vertical


### PR DESCRIPTION
I keep finding places where I need to choose something based on the axis of text, and the ergonomics of doing that right now are pretty bad. This commit introduces the constants for expressing vertical text and an easy way to look up the axis of text.

I'm open to other ways of doing this if you see alternatives.