### PR TITLE
Clean the recompute API

### DIFF
--- a/shaping/output.go
+++ b/shaping/output.go
@@ -119,14 +119,13 @@ func (u UnimplementedDirectionError) Error() string {
 // and can be used to speed up line wrapping logic.
 func (o *Output) RecomputeAdvance() {
 	advance := fixed.Int26_6(0)
-	switch o.Direction {
-	case di.DirectionLTR, di.DirectionRTL:
-		for _, g := range o.Glyphs {
-			advance += g.XAdvance
-		}
-	default: // vertical
+	if o.Direction.IsVertical() {
 		for _, g := range o.Glyphs {
 			advance += g.YAdvance
+		}
+	} else { // horizontal
+		for _, g := range o.Glyphs {
+			advance += g.XAdvance
 		}
 	}
 	o.Advance = advance
@@ -143,10 +142,9 @@ func (o *Output) RecalculateAll() error {
 		lowest  fixed.Int26_6
 	)
 
-	switch o.Direction {
-	default:
+	if o.Direction.IsVertical() {
 		return UnimplementedDirectionError{Direction: o.Direction}
-	case di.DirectionLTR, di.DirectionRTL:
+	} else { // horizontal
 		for i := range o.Glyphs {
 			g := &o.Glyphs[i]
 			advance += g.XAdvance

--- a/shaping/output.go
+++ b/shaping/output.go
@@ -117,9 +117,9 @@ func (u UnimplementedDirectionError) Error() string {
 // RecomputeAdvance updates only the Advance field based on the current
 // contents of the Glyphs field. It is faster than RecalculateAll(),
 // and can be used to speed up line wrapping logic.
-func (o *Output) RecomputeAdvance(dir di.Direction) {
+func (o *Output) RecomputeAdvance() {
 	advance := fixed.Int26_6(0)
-	switch dir {
+	switch o.Direction {
 	case di.DirectionLTR, di.DirectionRTL:
 		for _, g := range o.Glyphs {
 			advance += g.XAdvance
@@ -134,18 +134,18 @@ func (o *Output) RecomputeAdvance(dir di.Direction) {
 
 // RecalculateAll updates the all other fields of the Output
 // to match the current contents of the Glyphs field.
-// This method will fail with UnimplementedDirectionError if the provided
+// This method will fail with UnimplementedDirectionError if the Output
 // direction is unimplemented.
-func (o *Output) RecalculateAll(dir di.Direction) error {
+func (o *Output) RecalculateAll() error {
 	var (
 		advance fixed.Int26_6
 		tallest fixed.Int26_6
 		lowest  fixed.Int26_6
 	)
 
-	switch dir {
+	switch o.Direction {
 	default:
-		return UnimplementedDirectionError{Direction: dir}
+		return UnimplementedDirectionError{Direction: o.Direction}
 	case di.DirectionLTR, di.DirectionRTL:
 		for i := range o.Glyphs {
 			g := &o.Glyphs[i]

--- a/shaping/output_test.go
+++ b/shaping/output_test.go
@@ -152,8 +152,9 @@ func TestRecalculate(t *testing.T) {
 			output := shaping.Output{
 				Glyphs:     tc.Input,
 				LineBounds: expectedFontExtents,
+				Direction:  tc.Direction,
 			}
-			err := output.RecalculateAll(tc.Direction)
+			err := output.RecalculateAll()
 			if tc.Error != nil && !errors.As(err, &tc.Error) {
 				t.Errorf("expected error of type %T, got %T", tc.Error, err)
 			} else if tc.Error == nil && !reflect.DeepEqual(output, tc.Output) {

--- a/shaping/shaper.go
+++ b/shaping/shaper.go
@@ -112,7 +112,7 @@ func Shape(input Input) (Output, error) {
 		Descent: fixed.I(int(fontExtents.Descender)) >> scaleShift,
 		Gap:     fixed.I(int(fontExtents.LineGap)) >> scaleShift,
 	}
-	return out, out.RecalculateAll(input.Direction)
+	return out, out.RecalculateAll()
 }
 
 // countClusters tallies the number of runes and glyphs in each cluster


### PR DESCRIPTION
With #12 merged, we can simplify the Output.{RecomputeAdvance, RecalculateAll} signatures.
(This is safe because we never wan't to use a different direction than the once used to shape the input.)