### PR TITLE
di: add text progression types and method

### DIFF
--- a/di/direction.go
+++ b/di/direction.go
@@ -35,9 +35,9 @@ func (d Direction) Axis() Axis {
 func (d Direction) Progression() Progression {
 	switch d {
 	case DirectionTTB, DirectionLTR:
-		return FromOrigin
+		return FromUpperLeft
 	default:
-		return TowardOrigin
+		return TowardUpperLeft
 	}
 }
 
@@ -55,13 +55,14 @@ const (
 type Progression bool
 
 const (
-	// FromOrigin indicates text in which a reader starts reading
-	// at the origin and moves away from it. DirectionLTR and
-	// DirectionTTB are examples of FromOrigin Progression.
-	FromOrigin Progression = false
-	// TowardOrigin indicates text in which a reader stars reading
-	// at the opposite end of the text's Axis from the origin and
-	// moves towards it. DirectionRTL and DirectionBTT are examples
-	// of TowardOrigin progression.
-	TowardOrigin Progression = true
+	// FromUpperLeft indicates text in which a reader starts reading
+	// at the upper-left corner of the text and moves away from it.
+	// DirectionLTR and DirectionTTB are examples of FromUpperLeft
+	// Progression.
+	FromUpperLeft Progression = false
+	// TowardUpperLeft indicates text in which a reader starts reading
+	// at the opposite end of the text's Axis from the upper left corner
+	// and moves towards it. DirectionRTL and DirectionBTT are examples
+	// of TowardUpperLeft progression.
+	TowardUpperLeft Progression = true
 )

--- a/di/direction.go
+++ b/di/direction.go
@@ -31,10 +31,37 @@ func (d Direction) Axis() Axis {
 	}
 }
 
+// Progression returns the text layout progression for d.
+func (d Direction) Progression() Progression {
+	switch d {
+	case DirectionTTB, DirectionLTR:
+		return FromOrigin
+	default:
+		return TowardOrigin
+	}
+}
+
 // Axis indicates the axis of layout for a piece of text.
 type Axis bool
 
 const (
 	Horizontal Axis = false
 	Vertical   Axis = true
+)
+
+// Progression indicates how text is read within its Axis relative
+// to the origin (where the origin is the upper-left corner of the
+// text).
+type Progression bool
+
+const (
+	// FromOrigin indicates text in which a reader starts reading
+	// at the origin and moves away from it. DirectionLTR and
+	// DirectionTTB are examples of FromOrigin Progression.
+	FromOrigin Progression = false
+	// TowardOrigin indicates text in which a reader stars reading
+	// at the opposite end of the text's Axis from the origin and
+	// moves towards it. DirectionRTL and DirectionBTT are examples
+	// of TowardOrigin progression.
+	TowardOrigin Progression = true
 )

--- a/di/direction.go
+++ b/di/direction.go
@@ -35,9 +35,9 @@ func (d Direction) Axis() Axis {
 func (d Direction) Progression() Progression {
 	switch d {
 	case DirectionTTB, DirectionLTR:
-		return FromUpperLeft
+		return FromTopLeft
 	default:
-		return TowardUpperLeft
+		return TowardTopLeft
 	}
 }
 
@@ -50,19 +50,18 @@ const (
 )
 
 // Progression indicates how text is read within its Axis relative
-// to the origin (where the origin is the upper-left corner of the
-// text).
+// to the top left corner.
 type Progression bool
 
 const (
-	// FromUpperLeft indicates text in which a reader starts reading
-	// at the upper-left corner of the text and moves away from it.
-	// DirectionLTR and DirectionTTB are examples of FromUpperLeft
+	// FromTopLeft indicates text in which a reader starts reading
+	// at the top left corner of the text and moves away from it.
+	// DirectionLTR and DirectionTTB are examples of FromTopLeft
 	// Progression.
-	FromUpperLeft Progression = false
-	// TowardUpperLeft indicates text in which a reader starts reading
-	// at the opposite end of the text's Axis from the upper left corner
+	FromTopLeft Progression = false
+	// TowardTopLeft indicates text in which a reader starts reading
+	// at the opposite end of the text's Axis from the top left corner
 	// and moves towards it. DirectionRTL and DirectionBTT are examples
-	// of TowardUpperLeft progression.
-	TowardUpperLeft Progression = true
+	// of TowardTopLeft progression.
+	TowardTopLeft Progression = true
 )


### PR DESCRIPTION
This commit introduces a type that represents how a piece
of text is read relative to the origin as well as a
method to get the progression from any direction.

This information makes it easy to write algorithms that
operate on text of only one progression, but across any
axis.

Closes #14

Signed-off-by: Chris Waldon <christopher.waldon.dev@gmail.com>