### PR TITLE
[shaping] add a hook for a general face selection

### DIFF
--- a/shaping/input_test.go
+++ b/shaping/input_test.go
@@ -33,13 +33,13 @@ func Test_ignoreFaceChange(t *testing.T) {
 }
 
 // support any rune
-type universalFont struct{
+type universalFont struct {
 	fonts.Face
 }
 
 func (universalFont) NominalGlyph(rune) (font.GID, bool) { return 0, true }
 
-type upperFont struct{
+type upperFont struct {
 	fonts.Face
 }
 
@@ -47,7 +47,7 @@ func (upperFont) NominalGlyph(r rune) (font.GID, bool) {
 	return 0, unicode.IsUpper(r)
 }
 
-type lowerFont struct{
+type lowerFont struct {
 	fonts.Face
 }
 


### PR DESCRIPTION
One of my main motivation to discuss #17 is that I initially thought the shaping API would have to know about font descriptions to support the general capabilities I need. 

I now realize that it actually only requires a small addition to the shaping package. With this PR, the font index mechanism described in #17 may then entirely be implemented outside shaping (or even outside go-text).

Notice that I've written this PR to be entirely backward compatible. 
As a result, `SplitByFontGlyphs` and `SplitByFace` are somewhat redundant. We could remove `SplitByFontGlyphs` and expose the `fixedFontmap` type, as you wish.