### PR TITLE
shaping: fix and test cluster splitting bug

### DIFF
--- a/shaping/wrapping.go
+++ b/shaping/wrapping.go
@@ -256,10 +256,12 @@ type breakOption struct {
 // isValid returns whether a given option violates shaping rules (like breaking
 // a shaped text cluster).
 func (option breakOption) isValid(runeToGlyph []int, out Output) bool {
-	if option.breakAtRune+1 < len(runeToGlyph) {
+	breakAfter := option.breakAtRune - out.Runes.Offset
+	nextRune := breakAfter + 1
+	if nextRune < len(runeToGlyph) && breakAfter >= 0 {
 		// Check if this break is valid.
-		gIdx := runeToGlyph[option.breakAtRune]
-		g2Idx := runeToGlyph[option.breakAtRune+1]
+		gIdx := runeToGlyph[breakAfter]
+		g2Idx := runeToGlyph[nextRune]
 		cIdx := out.Glyphs[gIdx].ClusterIndex
 		c2Idx := out.Glyphs[g2Idx].ClusterIndex
 		if cIdx == c2Idx {

--- a/shaping/wrapping_test.go
+++ b/shaping/wrapping_test.go
@@ -1047,6 +1047,152 @@ func TestLineWrap(t *testing.T) {
 			},
 		},
 		{
+			// This test case verifies that the line wrapper rejects line break
+			// candidates that would split a glyph cluster at non-zero offsets
+			// within the shaped text.
+			name: "reject mid-cluster line breaks at non-zero offsets",
+			shaped: []Output{
+				{
+					Advance: fixed.I(10),
+					LineBounds: Bounds{
+						Ascent:  fixed.I(10),
+						Descent: fixed.I(5),
+						// No line gap.
+					},
+					GlyphBounds: Bounds{
+						Ascent: fixed.I(10),
+						// No glyphs descend.
+					},
+					Glyphs: []Glyph{
+						simpleGlyph(0),
+					},
+					Runes: Range{Count: 1},
+				},
+				{
+					Advance: fixed.I(10),
+					LineBounds: Bounds{
+						Ascent:  fixed.I(10),
+						Descent: fixed.I(5),
+						// No line gap.
+					},
+					GlyphBounds: Bounds{
+						Ascent: fixed.I(10),
+						// No glyphs descend.
+					},
+					Glyphs: []Glyph{
+						simpleGlyph(1),
+					},
+					Runes: Range{Count: 1, Offset: 1},
+				},
+				{
+					Advance: fixed.I(10 * 2),
+					LineBounds: Bounds{
+						Ascent:  fixed.I(10),
+						Descent: fixed.I(5),
+						// No line gap.
+					},
+					GlyphBounds: Bounds{
+						Ascent: fixed.I(10),
+						// No glyphs descend.
+					},
+					Glyphs: []Glyph{
+						complexGlyph(2, 2, 2),
+						complexGlyph(2, 2, 2),
+					},
+					Runes: Range{Count: 2, Offset: 2},
+				},
+				{
+					Advance: fixed.I(10),
+					LineBounds: Bounds{
+						Ascent:  fixed.I(10),
+						Descent: fixed.I(5),
+						// No line gap.
+					},
+					GlyphBounds: Bounds{
+						Ascent: fixed.I(10),
+						// No glyphs descend.
+					},
+					Glyphs: []Glyph{
+						simpleGlyph(4),
+					},
+					Runes: Range{Count: 1, Offset: 4},
+				},
+			},
+			// This unicode data was discovered in a fuzz test failure
+			// for Gio's text shaper.
+			paragraph: []rune{1593, 48, 32, 1474, 48},
+			maxWidth:  40,
+			expected: []Line{
+				[]Output{
+					{
+						Advance: fixed.I(10),
+						LineBounds: Bounds{
+							Ascent:  fixed.I(10),
+							Descent: fixed.I(5),
+							// No line gap.
+						},
+						GlyphBounds: Bounds{
+							Ascent: fixed.I(10),
+							// No glyphs descend.
+						},
+						Glyphs: []Glyph{
+							simpleGlyph(0),
+						},
+						Runes: Range{Count: 1},
+					},
+					{
+						Advance: fixed.I(10),
+						LineBounds: Bounds{
+							Ascent:  fixed.I(10),
+							Descent: fixed.I(5),
+							// No line gap.
+						},
+						GlyphBounds: Bounds{
+							Ascent: fixed.I(10),
+							// No glyphs descend.
+						},
+						Glyphs: []Glyph{
+							simpleGlyph(1),
+						},
+						Runes: Range{Count: 1, Offset: 1},
+					},
+					{
+						Advance: fixed.I(10 * 2),
+						LineBounds: Bounds{
+							Ascent:  fixed.I(10),
+							Descent: fixed.I(5),
+							// No line gap.
+						},
+						GlyphBounds: Bounds{
+							Ascent: fixed.I(10),
+							// No glyphs descend.
+						},
+						Glyphs: []Glyph{
+							complexGlyph(2, 2, 2),
+							complexGlyph(2, 2, 2),
+						},
+						Runes: Range{Count: 2, Offset: 2},
+					},
+					{
+						Advance: fixed.I(10),
+						LineBounds: Bounds{
+							Ascent:  fixed.I(10),
+							Descent: fixed.I(5),
+							// No line gap.
+						},
+						GlyphBounds: Bounds{
+							Ascent: fixed.I(10),
+							// No glyphs descend.
+						},
+						Glyphs: []Glyph{
+							simpleGlyph(4),
+						},
+						Runes: Range{Count: 1, Offset: 4},
+					},
+				},
+			},
+		},
+		{
 			// This test case verifies that line breaking does occur, and that
 			// all lines have proper offsets.
 			name:      "line break on last word",


### PR DESCRIPTION
I discovered that our logic to prevent splitting harfbuzz clusters during wrapping only worked if the run in consideration was at the beginning of the shaped text. A Gio fuzz test for rune accounting was failing as a result. I've fixed the logic and added a new test case to exercise the non-zero-offset cluster splitting case.

Signed-off-by: Chris Waldon <christopher.waldon.dev@gmail.com>