### PR TITLE
shaping: provide size in output

### DIFF
--- a/shaping/output.go
+++ b/shaping/output.go
@@ -86,6 +86,8 @@ func (b Bounds) LineHeight() fixed.Int26_6 {
 type Output struct {
 	// Advance is the distance the Dot has advanced.
 	Advance fixed.Int26_6
+	// Size is copied from the shaping.Input.Size that produced this Output.
+	Size fixed.Int26_6
 	// Glyphs are the shaped output text.
 	Glyphs []Glyph
 	// LineBounds describes the font's suggested line bounding dimensions. The

--- a/shaping/shaper.go
+++ b/shaping/shaper.go
@@ -110,6 +110,7 @@ func (t *HarfbuzzShaper) Shape(input Input) Output {
 		Glyphs:    glyphs,
 		Direction: input.Direction,
 		Face:      input.Face,
+		Size:      input.Size,
 	}
 	fontExtents := font.ExtentsForDirection(t.buf.Props.Direction)
 	out.LineBounds = Bounds{


### PR DESCRIPTION
This commit copies the shaping.Input's size to the corresponding shaping.Output. This makes shaping text with variable-sized runs much easier, as you don't need to do manual tracking of the run sizes.

Signed-off-by: Chris Waldon <christopher.waldon.dev@gmail.com>