### PR TITLE
Fix old go mod vendor

### DIFF
--- a/shaping/fuzz_test.go
+++ b/shaping/fuzz_test.go
@@ -1,4 +1,5 @@
 //go:build go1.18
+// +build go1.18
 
 package shaping
 


### PR DESCRIPTION
Go 1.16 (and earlier?) won't work without the old comment version