### PR TITLE
Minor improvements/cleanups suggested by staticcheck

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,13 +6,21 @@ jobs:
       matrix:
         go-version: [1.17.x, 1.18.x, 1.19.x]
         os: [ubuntu-latest]
+        
     runs-on: ${{ matrix.os }}
     steps:
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go-version }}
+
     - name: Checkout code
       uses: actions/checkout@v2
+    
     - name: Test
       run: go test ./...
+
+    - name: Staticcheck
+      run: |
+        go install honnef.co/go/tools/cmd/staticcheck@v0.3.3
+        staticcheck ./...

--- a/segmenter/unicode14_rules.go
+++ b/segmenter/unicode14_rules.go
@@ -421,8 +421,8 @@ func (cr *cursor) endIteration(isStart bool) {
 			cr.prevLine == ucd.BreakZW
 		if isStart || isLB10 { // Rule LB10
 			cr.prevLine = ucd.BreakAL
-		} else { // rule LB9 : ignore the rune for prevLine and prevPrevLine
-		}
+		} // else rule LB9 : ignore the rune for prevLine and prevPrevLine
+
 	} else { // regular update
 		cr.prevPrevLine = cr.prevLine
 		cr.prevLine = cr.line

--- a/shaping/shaper.go
+++ b/shaping/shaper.go
@@ -74,7 +74,7 @@ func (t *HarfbuzzShaper) Shape(input Input) Output {
 	t.buf.Props.Language = input.Language
 	t.buf.Props.Script = input.Script
 	// TODO: figure out what (if anything) to do if this type assertion fails.
-	font := harfbuzz.NewFont(input.Face.(harfbuzz.Face))
+	font := harfbuzz.NewFont(input.Face)
 	font.XScale = int32(input.Size.Ceil()) << scaleShift
 	font.YScale = font.XScale
 

--- a/shaping/wrapping.go
+++ b/shaping/wrapping.go
@@ -289,15 +289,6 @@ func newBreaker(seg *segmenter.Segmenter, text []rune) *breaker {
 	return br
 }
 
-// nextValid returns the next valid break candidate, if any. If ok is false, there are no candidates.
-func (b *breaker) nextValid(currentRuneToGlyph []int, currentOutput Output) (option breakOption, ok bool) {
-	option, ok = b.next()
-	for ok && !option.isValid(currentRuneToGlyph, currentOutput) {
-		option, ok = b.next()
-	}
-	return
-}
-
 // next returns a naive break candidate which may be invalid.
 func (b *breaker) next() (option breakOption, ok bool) {
 	if b.segmenter.Next() {


### PR DESCRIPTION
This fixes the three suggestions that staticcheck had:
```
segmenter/unicode14_rules.go:424:10: empty branch (SA9003)
shaping/shaper.go:77:27: type assertion to the same type: input.Face already has type harfbuzz.Face (S1040)
shaping/wrapping.go:293:19: func (*breaker).nextValid is unused (U1000)
```

I also added `staticcheck` to the GitHub Actions. We run this as part of our test suite within Fyne. Staticcheck gives a lot of great suggestions and makes sure that code quality stays on top. I genuinely believe that it is the best static analysis tool for Go :)