### PR TITLE
codeowners: define code owners for main branch

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @whereswaldon @benoitkugler @andydotxyz


### PR DESCRIPTION
This file should ensure that the three listed people are requested for review on every PR, and I think we can combine it with branch protection rules to enforce that at least one of these three people must approve, though I'm not sure if we can enforce requiring two.

This is my attempt to move us closer to the policy described [here](https://github.com/go-text/typesetting/discussions/36).