### PR TITLE
Wrapping Refactors

### DIFF
--- a/shaping/wrapping.go
+++ b/shaping/wrapping.go
@@ -522,14 +522,29 @@ func (l *LineWrapper) WrapNextLine(maxWidth int) (finalLine Line, done bool) {
 			// line, but keep lineCandidate unmodified so that later break
 			// options can be attempted to see if a more optimal solution is
 			// available.
-			if target := len(lineCandidate) + 1; cap(bestCandidate) < target {
-				bestCandidate = make([]Output, target-1, target)
-			} else if len(bestCandidate) < target {
-				bestCandidate = bestCandidate[:target-1]
-			}
+			bestCandidate = resize(bestCandidate, len(lineCandidate), len(lineCandidate)+1)
 			bestCandidate = bestCandidate[:copy(bestCandidate, lineCandidate)]
 			bestCandidate = append(bestCandidate, candidateRun)
 			l.currentRun = candidateCurrentRun
 		}
 	}
+}
+
+// resize returns input resized to have the provided length and at least the provided
+// capacity. It may copy the data if the provided capacity is greater than the capacity
+// of in. If the provided length is greater than the provided capacity, the capacity will
+// be used as the length.
+func resize(input []Output, length, capacity int) []Output {
+	if length > capacity {
+		length = capacity
+	}
+	out := input
+	if cap(input) < capacity {
+		out = make([]Output, capacity)
+		copy(out, input)
+	}
+	if len(out) != length {
+		out = out[:length]
+	}
+	return out
 }

--- a/shaping/wrapping.go
+++ b/shaping/wrapping.go
@@ -459,10 +459,6 @@ func (l *LineWrapper) WrapNextLine(maxWidth int) (finalLine Line, done bool) {
 	// incremented separately so that the candidate search can run ahead of the
 	// l.currentRun.
 	candidateCurrentRun := l.currentRun
-	incRun := func() bool {
-		candidateCurrentRun++
-		return candidateCurrentRun >= len(l.glyphRuns)
-	}
 
 	for {
 		run := l.glyphRuns[candidateCurrentRun]
@@ -472,7 +468,8 @@ func (l *LineWrapper) WrapNextLine(maxWidth int) (finalLine Line, done bool) {
 		}
 		for option.breakAtRune >= run.Runes.Count+run.Runes.Offset {
 			if l.lineStartRune >= run.Runes.Offset+run.Runes.Count {
-				if incRun() {
+				candidateCurrentRun++
+				if candidateCurrentRun >= len(l.glyphRuns) {
 					return bestCandidate, true
 				}
 				run = l.glyphRuns[candidateCurrentRun]
@@ -487,7 +484,8 @@ func (l *LineWrapper) WrapNextLine(maxWidth int) (finalLine Line, done bool) {
 			// candidate, just append it to the candidate line.
 			lineCandidate = append(lineCandidate, run)
 			candidateWidth += run.Advance
-			if incRun() {
+			candidateCurrentRun++
+			if candidateCurrentRun >= len(l.glyphRuns) {
 				return lineCandidate, true
 			}
 			run = l.glyphRuns[candidateCurrentRun]

--- a/shaping/wrapping.go
+++ b/shaping/wrapping.go
@@ -522,12 +522,20 @@ func (l *LineWrapper) WrapNextLine(maxWidth int) (finalLine Line, done bool) {
 			// line, but keep lineCandidate unmodified so that later break
 			// options can be attempted to see if a more optimal solution is
 			// available.
-			bestCandidate = resize(bestCandidate, len(lineCandidate), len(lineCandidate)+1)
-			bestCandidate = bestCandidate[:copy(bestCandidate, lineCandidate)]
-			bestCandidate = append(bestCandidate, candidateRun)
+			bestCandidate = commitCandidate(bestCandidate, lineCandidate, candidateRun)
 			l.currentRun = candidateCurrentRun
 		}
 	}
+}
+
+// commitCandidate efficiently updates destination to contain append(source, newRun),
+// returning the resulting slice. This operation only makes sense when destination
+// is not known to contain the elements of source already.
+func commitCandidate(destination, source []Output, newRun Output) []Output {
+	destination = resize(destination, len(source), len(source)+1)
+	destination = destination[:copy(destination, source)]
+	destination = append(destination, newRun)
+	return destination
 }
 
 // resize returns input resized to have the provided length and at least the provided

--- a/shaping/wrapping.go
+++ b/shaping/wrapping.go
@@ -408,6 +408,8 @@ func (l *LineWrapper) WrapParagraph(config WrapConfig, maxWidth int, paragraph [
 	return lines
 }
 
+// nextBreakOption returns the next rune offset at which the line can be broken,
+// if any. If it returns false, there are no more candidates.
 func (l *LineWrapper) nextBreakOption() (breakOption, bool) {
 	var option breakOption
 	if l.isUnused {


### PR DESCRIPTION
I'm working to implement the insertion of a text truncation symbol, and I've found the wrapping algorithm to be quite difficult to read (it's long, it's intricate, etc). These commits are an effort to make the core algorithm clearer, and to provide reusable helpers. There's definitely more that can be done here, but I thought these changes made a dent, and are probably not contentious.