### PR TITLE
ci: update to latest staticcheck

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -17,5 +17,5 @@ jobs:
 
     - name: Staticcheck
       run: |
-        go install honnef.co/go/tools/cmd/staticcheck@v0.3.3
+        go install honnef.co/go/tools/cmd/staticcheck@2023.1.3
         staticcheck ./...

--- a/harfbuzz/shaper_perf_test.go
+++ b/harfbuzz/shaper_perf_test.go
@@ -1,7 +1,7 @@
 package harfbuzz
 
 import (
-	"io/ioutil" //lint:ignore SA1019 since we still want to support version under 1.16
+	"io/ioutil"
 	"testing"
 
 	"github.com/go-text/typesetting/language"

--- a/segmenter/segmenter_test.go
+++ b/segmenter/segmenter_test.go
@@ -4,7 +4,7 @@ package segmenter
 
 import (
 	"fmt"
-	"io/ioutil" //lint:ignore SA1019 since we still want to support version under 1.16
+	"io/ioutil"
 	"reflect"
 	"strconv"
 	"strings"

--- a/shaping/output_test.go
+++ b/shaping/output_test.go
@@ -36,28 +36,6 @@ var (
 		Height:   -fixed.I(int(10)),
 		YBearing: fixed.I(int(10)),
 	}
-	leftExtentGlyph = shaping.Glyph{
-		GlyphID:  leftExtentGID,
-		XAdvance: fixed.I(int(5)),
-		YAdvance: fixed.I(int(5)),
-		XOffset:  fixed.I(int(0)),
-		YOffset:  fixed.I(int(0)),
-		Width:    fixed.I(int(10)),
-		Height:   -fixed.I(int(10)),
-		YBearing: fixed.I(int(10)),
-		XBearing: fixed.I(int(5)),
-	}
-	rightExtentGlyph = shaping.Glyph{
-		GlyphID:  rightExtentGID,
-		XAdvance: fixed.I(int(5)),
-		YAdvance: fixed.I(int(5)),
-		XOffset:  fixed.I(int(0)),
-		YOffset:  fixed.I(int(0)),
-		Width:    fixed.I(int(10)),
-		Height:   -fixed.I(int(10)),
-		YBearing: fixed.I(int(10)),
-		XBearing: fixed.I(int(0)),
-	}
 	deepGlyph = shaping.Glyph{
 		GlyphID:  deepGID,
 		XAdvance: fixed.I(int(10)),


### PR DESCRIPTION
Just a version bump for the linter and some adaptations to newer lint rules.