### PR TITLE
Truncator support

### DIFF
--- a/shaping/fuzz_test.go
+++ b/shaping/fuzz_test.go
@@ -33,7 +33,7 @@ func FuzzE2E(f *testing.F) {
 			t.Errorf("expected %d shaped runes, got %d", len(textInput), out.Runes.Count)
 		}
 		var l LineWrapper
-		outs := l.WrapParagraph(WrapConfig{}, 100, textInput, out)
+		outs, _ := l.WrapParagraph(WrapConfig{}, 100, textInput, out)
 		totalRunes := 0
 		for _, l := range outs {
 			for _, run := range l {

--- a/shaping/wrapping.go
+++ b/shaping/wrapping.go
@@ -319,6 +319,16 @@ type WrapConfig struct {
 	// TruncateAfterLines is the number of lines of text to allow before truncating
 	// the text. A value of zero means no limit.
 	TruncateAfterLines int
+	// Truncator, if provided, will be inserted at the end of a truncated line. This
+	// feature is only active if TruncateAfterLines is nonzero.
+	Truncator Output
+}
+
+// WithTruncator returns a copy of WrapConfig with the Truncator field set to the
+// result of shaping input with shaper.
+func (w WrapConfig) WithTruncator(shaper Shaper, input Input) WrapConfig {
+	w.Truncator = shaper.Shape(input)
+	return w
 }
 
 // runMapper efficiently maps a run to glyph clusters.
@@ -392,20 +402,21 @@ func (l *LineWrapper) Prepare(config WrapConfig, paragraph []rune, shapedRuns ..
 // WrapParagraph wraps the paragraph's shaped glyphs to a constant maxWidth.
 // It is equivalent to iteratively invoking WrapLine with a constant maxWidth.
 // If the config has a non-zero TruncateAfterLines, WrapParagraph will return at most
-// that many lines.
-func (l *LineWrapper) WrapParagraph(config WrapConfig, maxWidth int, paragraph []rune, shapedRuns ...Output) []Line {
+// that many lines. The truncated return value is the count of runes truncated from
+// the end of the text.
+func (l *LineWrapper) WrapParagraph(config WrapConfig, maxWidth int, paragraph []rune, shapedRuns ...Output) (_ []Line, truncated int) {
 	if len(shapedRuns) == 1 && shapedRuns[0].Advance.Ceil() < maxWidth {
-		return []Line{shapedRuns}
+		return []Line{shapedRuns}, 0
 	}
 	l.Prepare(config, paragraph, shapedRuns...)
 	var lines []Line
 	var done bool
 	for !done {
 		var line Line
-		line, done = l.WrapNextLine(maxWidth)
+		line, truncated, done = l.WrapNextLine(maxWidth)
 		lines = append(lines, line)
 	}
-	return lines
+	return lines, truncated
 }
 
 // nextBreakOption returns the next rune offset at which the line can be broken,
@@ -426,16 +437,72 @@ func (l *LineWrapper) nextBreakOption() (breakOption, bool) {
 	return option, true
 }
 
+type fillResult uint8
+
+const (
+	// noCandidate indicates that it is not possible to compose a new line candidate using the provided
+	// breakOption, so the best known line should be used instead.
+	noCandidate fillResult = iota
+	// noRunWithBreak indicates that none of the runs available to the line wrapper contain the break
+	// option, so the returned candidate is the best option.
+	noRunWithBreak
+	// newCandidate indicates that the returned line candidate is valid.
+	newCandidate
+)
+
+// fillUntil tries to fill the provided line candidate slice with runs until it reaches a run containing the
+// provided break option. It returns the index of the run containing the option, the new width of the candidate
+// line, the contents of the new candidate line, and a result indicating how to proceed.
+func (l *LineWrapper) fillUntil(option breakOption, startRunIdx int, startWidth fixed.Int26_6, lineCandidate []Output) (newRunIdx int, newWidth fixed.Int26_6, newLineCandidate []Output, status fillResult) {
+	run := l.glyphRuns[startRunIdx]
+	for option.breakAtRune >= run.Runes.Count+run.Runes.Offset {
+		if l.lineStartRune >= run.Runes.Offset+run.Runes.Count {
+			startRunIdx++
+			if startRunIdx >= len(l.glyphRuns) {
+				return startRunIdx, startWidth, lineCandidate, noCandidate
+			}
+			run = l.glyphRuns[startRunIdx]
+			continue
+		} else if l.lineStartRune > run.Runes.Offset {
+			// If part of this run has already been used on a previous line, trim
+			// the runes corresponding to those glyphs off.
+			l.mapper.mapRun(startRunIdx, run)
+			run = cutRun(run, l.mapper.mapping, l.lineStartRune, run.Runes.Count+run.Runes.Offset)
+		}
+		// While the run being processed doesn't contain the current line breaking
+		// candidate, just append it to the candidate line.
+		lineCandidate = append(lineCandidate, run)
+		startWidth += run.Advance
+		startRunIdx++
+		if startRunIdx >= len(l.glyphRuns) {
+			return startRunIdx, startWidth, lineCandidate, noRunWithBreak
+		}
+		run = l.glyphRuns[startRunIdx]
+	}
+	return startRunIdx, startWidth, lineCandidate, newCandidate
+}
+
 // WrapNextLine wraps the shaped glyphs of a paragraph to a particular max width.
 // It is meant to be called iteratively to wrap each line, allowing lines to
 // be wrapped to different widths within the same paragraph. When done is true,
 // subsequent calls to WrapNextLine (without calling Prepare) will return a nil line.
-func (l *LineWrapper) WrapNextLine(maxWidth int) (finalLine Line, done bool) {
+// The truncated return value is the count of runes truncated from the end of the line,
+// if this line was truncated.
+func (l *LineWrapper) WrapNextLine(maxWidth int) (finalLine Line, truncated int, done bool) {
 	defer func() {
+		if len(finalLine) > 0 {
+			finalRun := finalLine[len(finalLine)-1]
+			l.lineStartRune = finalRun.Runes.Count + finalRun.Runes.Offset
+		}
+		done = done || l.lineStartRune >= l.breaker.totalRunes
 		if l.truncating {
 			l.config.TruncateAfterLines--
 			if l.config.TruncateAfterLines == 0 {
 				done = true
+				truncated = l.breaker.totalRunes - l.lineStartRune
+			}
+			if truncated > 0 {
+				finalLine = append(finalLine, l.config.Truncator)
 			}
 		}
 		if done {
@@ -443,98 +510,108 @@ func (l *LineWrapper) WrapNextLine(maxWidth int) (finalLine Line, done bool) {
 		}
 	}()
 	if !l.more {
-		return nil, true
+		return nil, truncated, true
 	} else if len(l.glyphRuns) == 0 {
-		return nil, true
+		return nil, truncated, true
 	} else if len(l.glyphRuns[0].Glyphs) == 0 {
 		// Pass empty lines through as empty.
 		l.glyphRuns[0].Runes = Range{Count: l.breaker.totalRunes}
-		return Line([]Output{l.glyphRuns[0]}), true
+		return Line([]Output{l.glyphRuns[0]}), truncated, true
 	} else if len(l.glyphRuns) == 1 && l.glyphRuns[0].Advance.Ceil() < maxWidth {
-		return Line(l.glyphRuns), true
+		return Line(l.glyphRuns), truncated, true
 	}
 
-	lineCandidate, bestCandidate := []Output{}, []Output{}
-	candidateWidth := fixed.I(0)
+	// lineCandidate is filled with runs as we search for valid line breaks. When we find a valid
+	// option, we commit it into bestCandidate and keep looking.
+	var lineCandidate, bestCandidate []Output
+	// lineWidth tracks the width of the lineCandidate.
+	lineWidth := fixed.I(0)
+	var result fillResult
 
-	// candidateCurrentRun tracks the glyph run in use by the lineCandidate. It is
+	// lineRun tracks the glyph run in use by the lineCandidate. It is
 	// incremented separately so that the candidate search can run ahead of the
 	// l.currentRun.
-	candidateCurrentRun := l.currentRun
+	lineRun := l.currentRun
+
+	// truncating tracks whether this line should consider truncation options.
+	truncating := l.config.TruncateAfterLines == 1
+	// truncatedMaxWidth holds the maximum width of the line available for text if the truncator
+	// is occupying part of the line.
+	truncatedMaxWidth := maxWidth - l.config.Truncator.Advance.Ceil()
 
 	for {
-		run := l.glyphRuns[candidateCurrentRun]
 		option, ok := l.nextBreakOption()
 		if !ok {
-			return bestCandidate, true
+			return bestCandidate, truncated, true
 		}
-		for option.breakAtRune >= run.Runes.Count+run.Runes.Offset {
-			if l.lineStartRune >= run.Runes.Offset+run.Runes.Count {
-				candidateCurrentRun++
-				if candidateCurrentRun >= len(l.glyphRuns) {
-					return bestCandidate, true
-				}
-				run = l.glyphRuns[candidateCurrentRun]
-				continue
-			} else if l.lineStartRune > run.Runes.Offset {
-				// If part of this run has already been used on a previous line, trim
-				// the runes corresponding to those glyphs off.
-				l.mapper.mapRun(candidateCurrentRun, run)
-				run = cutRun(run, l.mapper.mapping, l.lineStartRune, run.Runes.Count+run.Runes.Offset)
-			}
-			// While the run being processed doesn't contain the current line breaking
-			// candidate, just append it to the candidate line.
-			lineCandidate = append(lineCandidate, run)
-			candidateWidth += run.Advance
-			candidateCurrentRun++
-			if candidateCurrentRun >= len(l.glyphRuns) {
-				return lineCandidate, true
-			}
-			run = l.glyphRuns[candidateCurrentRun]
+		lineRun, lineWidth, lineCandidate, result = l.fillUntil(
+			option,
+			lineRun,
+			lineWidth,
+			lineCandidate,
+		)
+		if result == noCandidate {
+			return bestCandidate, truncated, true
+		} else if result == noRunWithBreak {
+			return lineCandidate, truncated, true
 		}
-		l.mapper.mapRun(candidateCurrentRun, run)
+		run := l.glyphRuns[lineRun]
+		l.mapper.mapRun(lineRun, run)
 		if !option.isValid(l.mapper.mapping, run) {
 			// Reject invalid line break candidate and acquire a new one.
 			continue
 		}
 		candidateRun := cutRun(run, l.mapper.mapping, l.lineStartRune, option.breakAtRune)
-		if (candidateRun.Advance + candidateWidth).Ceil() > maxWidth {
+		candidateLineWidth := (candidateRun.Advance + lineWidth).Ceil()
+		if candidateLineWidth > maxWidth {
 			// The run doesn't fit on the line.
 			if len(bestCandidate) < 1 {
+				if truncating {
+					return bestCandidate, truncated, true
+				}
 				// There is no existing candidate that fits, and we have just hit the
-				// first line breaking canddiate. Commit this break position as the
+				// first line breaking candidate. Commit this break position as the
 				// best available, even though it doesn't fit.
 				lineCandidate = append(lineCandidate, candidateRun)
-				l.lineStartRune = candidateRun.Runes.Offset + candidateRun.Runes.Count
-				l.currentRun = candidateCurrentRun
-				return lineCandidate, l.lineStartRune >= l.breaker.totalRunes
+				l.currentRun = lineRun
+				return lineCandidate, truncated, false
 			} else {
 				// The line is a valid, shorter wrapping. Return it and mark that
 				// we should reuse the current line break candidate on the next
 				// line.
 				l.isUnused = true
-				finalRunRunes := bestCandidate[len(bestCandidate)-1].Runes
-				l.lineStartRune = finalRunRunes.Count + finalRunRunes.Offset
-				return bestCandidate, false
+				return bestCandidate, truncated, false
 			}
+		} else if truncating && candidateLineWidth > truncatedMaxWidth {
+			// The run would not fit if truncated.
+			finalRunRune := candidateRun.Runes.Count + candidateRun.Runes.Offset
+			if finalRunRune == l.breaker.totalRunes {
+				// The run contains the entire end of the text, so no truncation is
+				// necessary.
+				bestCandidate = commitCandidate(bestCandidate, lineCandidate, candidateRun)
+				l.currentRun = lineRun
+				return bestCandidate, truncated, true
+			}
+			// We must truncate the line in order to show it.
+			return bestCandidate, truncated, true
 		} else {
 			// The run does fit on the line. Commit this line as the best known
 			// line, but keep lineCandidate unmodified so that later break
 			// options can be attempted to see if a more optimal solution is
 			// available.
 			bestCandidate = commitCandidate(bestCandidate, lineCandidate, candidateRun)
-			l.currentRun = candidateCurrentRun
+			l.currentRun = lineRun
 		}
 	}
 }
 
-// commitCandidate efficiently updates destination to contain append(source, newRun),
+// commitCandidate efficiently updates destination to contain append(source, newRuns...),
 // returning the resulting slice. This operation only makes sense when destination
 // is not known to contain the elements of source already.
-func commitCandidate(destination, source []Output, newRun Output) []Output {
+func commitCandidate(destination, source []Output, newRuns ...Output) []Output {
 	destination = resize(destination, len(source), len(source)+1)
 	destination = destination[:copy(destination, source)]
-	destination = append(destination, newRun)
+	destination = append(destination, newRuns...)
 	return destination
 }
 


### PR DESCRIPTION
This commit builds upon #44 to actually implement a text truncator symbol.

Some design choices:

- I tried to implement what we discussed in #28 towards the end of the thread.
- The `Truncator` is a single `Output`. This limits it to being a single font face, size, script, and language, though it can contain any number of glyphs. Supporting a `[]Output` truncator is a solid complexity hike, and I'm not sure that they are really used in practice.
- To make it easier to populate the `Truncator` field, I've provided a helper on `WrapConfig` that accepts a `Shaper` and `Input`.
- Applications often want to know how much of the string was truncated. I've made this an additional return value from the wrapping functions because I didn't see a clearer way to communicate it right now.

Only the final commit in this PR is new. Please focus review on that and review the rest on #44 