### PR TITLE
Fix leak if fonts are replaced in usage

### DIFF
--- a/harfbuzz/buffer.go
+++ b/harfbuzz/buffer.go
@@ -105,8 +105,7 @@ type Buffer struct {
 
 	haveOutput bool
 
-	planCache     map[Face][]*shapePlan
-	planCacheLock *sync.Mutex
+	planCache map[Face][]*shapePlan
 }
 
 // NewBuffer allocate a storage with default options.
@@ -116,7 +115,6 @@ func NewBuffer() *Buffer {
 		ClusterLevel:  MonotoneGraphemes,
 		maxOps:        maxOpsDefault,
 		planCache:     map[Face][]*shapePlan{},
-		planCacheLock: &sync.Mutex{},
 	}
 }
 

--- a/harfbuzz/buffer.go
+++ b/harfbuzz/buffer.go
@@ -2,6 +2,7 @@ package harfbuzz
 
 import (
 	"math"
+	"sync"
 
 	"github.com/go-text/typesetting/language"
 	"github.com/go-text/typesetting/opentype/tables"
@@ -103,6 +104,9 @@ type Buffer struct {
 	scratchFlags bufferScratchFlags /* Have space-fallback, etc. */
 
 	haveOutput bool
+
+	planCache     map[Face][]*shapePlan
+	planCacheLock sync.Mutex
 }
 
 // NewBuffer allocate a storage with default options.
@@ -111,6 +115,7 @@ func NewBuffer() *Buffer {
 	return &Buffer{
 		ClusterLevel: MonotoneGraphemes,
 		maxOps:       maxOpsDefault,
+		planCache:    map[Face][]*shapePlan{},
 	}
 }
 

--- a/harfbuzz/buffer.go
+++ b/harfbuzz/buffer.go
@@ -106,16 +106,17 @@ type Buffer struct {
 	haveOutput bool
 
 	planCache     map[Face][]*shapePlan
-	planCacheLock sync.Mutex
+	planCacheLock *sync.Mutex
 }
 
 // NewBuffer allocate a storage with default options.
 // It should then be populated with `AddRunes` and shapped with `Shape`.
 func NewBuffer() *Buffer {
 	return &Buffer{
-		ClusterLevel: MonotoneGraphemes,
-		maxOps:       maxOpsDefault,
-		planCache:    map[Face][]*shapePlan{},
+		ClusterLevel:  MonotoneGraphemes,
+		maxOps:        maxOpsDefault,
+		planCache:     map[Face][]*shapePlan{},
+		planCacheLock: &sync.Mutex{},
 	}
 }
 

--- a/harfbuzz/buffer.go
+++ b/harfbuzz/buffer.go
@@ -2,7 +2,6 @@ package harfbuzz
 
 import (
 	"math"
-	"sync"
 
 	"github.com/go-text/typesetting/language"
 	"github.com/go-text/typesetting/opentype/tables"

--- a/harfbuzz/shape.go
+++ b/harfbuzz/shape.go
@@ -140,9 +140,6 @@ func (b *Buffer) newShapePlanCached(font *Font, props SegmentProperties,
 	var key shapePlan
 	key.init(false, font, props, userFeatures, coords)
 
-	b.planCacheLock.Lock()
-	defer b.planCacheLock.Unlock()
-
 	plans := b.planCache[font.face]
 
 	for _, plan := range plans {


### PR DESCRIPTION
Move plan cache to the buffer object so we don't leak if the shaper / font is not needed any more

Fixes #47