### PR TITLE
Add an API to query font metadata such as family name and style

### DIFF
--- a/opentype/api/cmap.go
+++ b/opentype/api/cmap.go
@@ -81,57 +81,37 @@ func ProcessCmap(cmap tables.Cmap) (Cmap, UnicodeVariations, error) {
 	}
 
 	// now find the best cmap, following harfbuzz/src/hb-ot-cmap-table.hh
-	const (
-		PlatformUnicode tables.PlatformID = iota
-		PlatformMac
-		PlatformIso /* deprecated */
-		PlatformMicrosoft
-		PlatformCustom
-		_
-		_
-		PlatformAdobe /* artificial */
-	)
-	const (
-		PEUnicodeDefault     = tables.EncodingID(0)
-		PEUnicodeBMP         = tables.EncodingID(3)
-		PEUnicodeFull        = tables.EncodingID(4)
-		PEUnicodeFull13      = tables.EncodingID(6)
-		PEMacRoman           = PEUnicodeDefault
-		PEMicrosoftSymbolCs  = tables.EncodingID(0)
-		PEMicrosoftUnicodeCs = tables.EncodingID(1)
-		PEMicrosoftUcs4      = tables.EncodingID(10)
-	)
 
 	// Prefer symbol if available.
-	if index := findSubtable(cmapID{PlatformMicrosoft, PEMicrosoftSymbolCs}, candidateIds); index != -1 {
+	if index := findSubtable(cmapID{tables.PlatformMicrosoft, tables.PEMicrosoftSymbolCs}, candidateIds); index != -1 {
 		return candidates[index], uv, nil
 	}
 
 	/* 32-bit subtables. */
-	if index := findSubtable(cmapID{PlatformMicrosoft, PEMicrosoftUcs4}, candidateIds); index != -1 {
+	if index := findSubtable(cmapID{tables.PlatformMicrosoft, tables.PEMicrosoftUcs4}, candidateIds); index != -1 {
 		return candidates[index], uv, nil
 	}
-	if index := findSubtable(cmapID{PlatformUnicode, PEUnicodeFull13}, candidateIds); index != -1 {
+	if index := findSubtable(cmapID{tables.PlatformUnicode, tables.PEUnicodeFull13}, candidateIds); index != -1 {
 		return candidates[index], uv, nil
 	}
-	if index := findSubtable(cmapID{PlatformUnicode, PEUnicodeFull}, candidateIds); index != -1 {
+	if index := findSubtable(cmapID{tables.PlatformUnicode, tables.PEUnicodeFull}, candidateIds); index != -1 {
 		return candidates[index], uv, nil
 	}
 
 	/* 16-bit subtables. */
-	if index := findSubtable(cmapID{PlatformMicrosoft, PEMicrosoftUnicodeCs}, candidateIds); index != -1 {
+	if index := findSubtable(cmapID{tables.PlatformMicrosoft, tables.PEMicrosoftUnicodeCs}, candidateIds); index != -1 {
 		return candidates[index], uv, nil
 	}
-	if index := findSubtable(cmapID{PlatformUnicode, PEUnicodeBMP}, candidateIds); index != -1 {
+	if index := findSubtable(cmapID{tables.PlatformUnicode, tables.PEUnicodeBMP}, candidateIds); index != -1 {
 		return candidates[index], uv, nil
 	}
-	if index := findSubtable(cmapID{PlatformUnicode, 2}, candidateIds); index != -1 { // deprecated
+	if index := findSubtable(cmapID{tables.PlatformUnicode, 2}, candidateIds); index != -1 { // deprecated
 		return candidates[index], uv, nil
 	}
-	if index := findSubtable(cmapID{PlatformUnicode, 1}, candidateIds); index != -1 { // deprecated
+	if index := findSubtable(cmapID{tables.PlatformUnicode, 1}, candidateIds); index != -1 { // deprecated
 		return candidates[index], uv, nil
 	}
-	if index := findSubtable(cmapID{PlatformUnicode, 0}, candidateIds); index != -1 { // deprecated
+	if index := findSubtable(cmapID{tables.PlatformUnicode, 0}, candidateIds); index != -1 { // deprecated
 		return candidates[index], uv, nil
 	}
 
@@ -162,11 +142,6 @@ func findSubtable(id cmapID, cmaps []cmapID) int {
 
 // ---------------------------------- Format 0 ----------------------------------
 
-var macintoshEncoding = [256]rune{
-	0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 196, 197, 199, 201, 209, 214, 220, 225, 224, 226, 228, 227, 229, 231, 233, 232, 234, 235, 237, 236, 238, 239, 241, 243, 242, 244, 246, 245, 250, 249, 251, 252, 8224, 176, 162, 163, 167, 8226, 182, 223, 174, 169, 8482, 180, 168, 8800, 198, 216, 8734, 177, 8804, 8805, 165, 181, 8706, 8721, 8719, 960, 8747, 170, 186, 937, 230, 248, 191, 161, 172, 8730, 402, 8776, 8710, 171, 187, 8230, 160, 192, 195, 213, 338, 339, 8211, 8212, 8220, 8221, 8216, 8217, 247, 9674, 255, 376, 8260, 8364,
-	8249, 8250, 64257, 64258, 8225, 183, 8218, 8222, 8240, 194, 202, 193, 203, 200, 205, 206, 207, 204, 211, 212, 63743, 210, 218, 219, 217, 305, 710, 732, 175, 728, 729, 730, 184, 733, 731, 711,
-}
-
 // use Macintosh encoding, storing indexIntoEncoding -> glyphIndex
 type cmap0 map[rune]uint8
 
@@ -176,7 +151,7 @@ func newCmap0(cm tables.CmapSubtable0) cmap0 {
 		if b == 0 {
 			continue
 		}
-		out[macintoshEncoding[b]] = gid
+		out[tables.DecodeMacintoshByte(byte(b))] = gid
 	}
 	return out
 }

--- a/opentype/api/font/font.go
+++ b/opentype/api/font/font.go
@@ -90,7 +90,7 @@ func NewFont(ld *loader.Loader) (*Font, error) {
 		return nil, err
 	}
 
-	out.head, err = loadHeadTable(ld)
+	out.head, err = LoadHeadTable(ld)
 	if err != nil {
 		return nil, err
 	}
@@ -104,10 +104,11 @@ func NewFont(ld *loader.Loader) (*Font, error) {
 		return nil, err
 	}
 
-	// we considerer all the following tables as optional,
+	// We considerer all the following tables as optional,
 	// since, in practice, users won't have much control on the
 	// font files they use
-	// ignoring the errors on `RawTable` is OK : it will trigger an error on the next tables.ParseXXX,
+	//
+	// Ignoring the errors on `RawTable` is OK : it will trigger an error on the next tables.ParseXXX,
 	// which in turn will return a zero value
 
 	raw, _ = ld.RawTable(loader.MustNewTag("fvar"))
@@ -220,9 +221,9 @@ func NewFont(ld *loader.Loader) (*Font, error) {
 
 var bhedTag = loader.MustNewTag("bhed")
 
-// loads the table corresponding to the 'head' tag.
-// if a 'bhed' Apple table is present, it replaces the 'head' one
-func loadHeadTable(ld *loader.Loader) (tables.Head, error) {
+// LoadHeadTable loads the table corresponding to the 'head' tag.
+// If a 'bhed' Apple table is present, it replaces the 'head' one.
+func LoadHeadTable(ld *loader.Loader) (tables.Head, error) {
 	var (
 		s   []byte
 		err error

--- a/opentype/api/metadata/aspect.go
+++ b/opentype/api/metadata/aspect.go
@@ -1,0 +1,287 @@
+package metadata
+
+import (
+	"strings"
+)
+
+// name values corresponding to the xxxConsts arrays
+var (
+	styleStrings   [len(styleConsts)]string
+	weightStrings  [len(weightConsts)]string
+	stretchStrings [len(stretchConsts)]string
+)
+
+func init() {
+	for i, v := range styleConsts {
+		styleStrings[i] = v.name
+	}
+	for i, v := range weightConsts {
+		weightStrings[i] = v.name
+	}
+	for i, v := range stretchConsts {
+		stretchStrings[i] = v.name
+	}
+}
+
+var styleConsts = [...]struct {
+	name  string
+	value Style
+}{
+	{"italic", StyleItalic},
+	{"kursiv", StyleItalic},
+	{"oblique", StyleItalic}, // map Oblique to Italic
+}
+
+var weightConsts = [...]struct {
+	name  string
+	value Weight
+}{
+	{"thin", WeightThin},
+	{"extralight", WeightExtraLight},
+	{"ultralight", WeightExtraLight},
+	{"light", WeightLight},
+	{"demilight", (WeightLight + WeightNormal) / 2},
+	{"semilight", (WeightLight + WeightNormal) / 2},
+	{"book", WeightNormal - 20},
+	{"regular", WeightNormal},
+	{"normal", WeightNormal},
+	{"medium", WeightMedium},
+	{"demibold", WeightSemibold},
+	{"demi", WeightSemibold},
+	{"semibold", WeightSemibold},
+	{"extrabold", WeightExtraBold},
+	{"superbold", WeightExtraBold},
+	{"ultrabold", WeightExtraBold},
+	{"bold", WeightBold},
+	{"ultrablack", WeightBlack + 20},
+	{"superblack", WeightBlack + 20},
+	{"extrablack", WeightBlack + 20},
+	{"black", WeightBlack},
+	{"heavy", WeightBlack},
+}
+
+var stretchConsts = [...]struct {
+	name  string
+	value Stretch
+}{
+	{"ultracondensed", StretchUltraCondensed},
+	{"extracondensed", StretchExtraCondensed},
+	{"semicondensed", StretchSemiCondensed},
+	{"condensed", StretchCondensed},
+	{"normal", StretchNormal},
+	{"semiexpanded", StretchSemiExpanded},
+	{"extraexpanded", StretchExtraExpanded},
+	{"ultraexpanded", StretchUltraExpanded},
+	{"expanded", StretchExpanded},
+	{"extended", StretchExpanded},
+}
+
+// Style (also called slant) allows italic or oblique faces to be selected.
+type Style uint8
+
+// note that we use the 0 value to indicate no style has been found yet
+const (
+	// A face that is neither italic not obliqued.
+	StyleNormal Style = iota + 1
+	// A form that is generally cursive in nature or slanted.
+	// This groups what is usually called Italic or Oblique.
+	StyleItalic
+)
+
+// Weight is the degree of blackness or stroke thickness of a font.
+// This value ranges from 100.0 to 900.0, with 400.0 as normal.
+type Weight float32
+
+const (
+	// Thin weight (100), the thinnest value.
+	WeightThin Weight = 100
+	// Extra light weight (200).
+	WeightExtraLight Weight = 200
+	// Light weight (300).
+	WeightLight Weight = 300
+	// Normal (400).
+	WeightNormal Weight = 400
+	// Medium weight (500, higher than normal).
+	WeightMedium Weight = 500
+	// Semibold weight (600).
+	WeightSemibold Weight = 600
+	// Bold weight (700).
+	WeightBold Weight = 700
+	// Extra-bold weight (800).
+	WeightExtraBold Weight = 800
+	// Black weight (900), the thickest value.
+	WeightBlack Weight = 900
+)
+
+// Stretch is the width of a font as an approximate fraction of the normal width.
+// Widths range from 0.5 to 2.0 inclusive, with 1.0 as the normal width.
+type Stretch float32
+
+const (
+	// Ultra-condensed width (50%), the narrowest possible.
+	StretchUltraCondensed Stretch = 0.5
+	// Extra-condensed width (62.5%).
+	StretchExtraCondensed Stretch = 0.625
+	// Condensed width (75%).
+	StretchCondensed Stretch = 0.75
+	// Semi-condensed width (87.5%).
+	StretchSemiCondensed Stretch = 0.875
+	// Normal width (100%).
+	StretchNormal Stretch = 1.0
+	// Semi-expanded width (112.5%).
+	StretchSemiExpanded Stretch = 1.125
+	// Expanded width (125%).
+	StretchExpanded Stretch = 1.25
+	// Extra-expanded width (150%).
+	StretchExtraExpanded Stretch = 1.5
+	// Ultra-expanded width (200%), the widest possible.
+	StretchUltraExpanded Stretch = 2.0
+)
+
+// Aspect stores the properties that specify which font in a family to use:
+// style, weight, and stretchiness.
+type Aspect struct {
+	Style   Style
+	Weight  Weight
+	Stretch Stretch
+}
+
+// use rawAspect and additionalStyle to infer the aspect
+func (fd *fontDescriptor) aspect() Aspect {
+	out := fd.rawAspect() // load the aspect properties ...
+
+	// ... try to fill the missing one with the "style"
+	out.inferFromStyle(fd.additionalStyle())
+
+	// ... and finally add default to regular values :
+	// StyleNormal, WeightNormal, StretchNormal
+	out.setDefaults()
+
+	return out
+}
+
+// some fonts includes aspect information in a string description,
+// usually called "style"
+// inferFromStyle scans such a string and fills the missing fields,
+func (as *Aspect) inferFromStyle(additionalStyle string) {
+	additionalStyle = normalizeFamily(additionalStyle)
+
+	if as.Style == 0 {
+		if index := stringContainsConst(additionalStyle, styleStrings[:]); index != -1 {
+			as.Style = styleConsts[index].value
+		}
+	}
+
+	if as.Weight == 0 {
+		if index := stringContainsConst(additionalStyle, weightStrings[:]); index != -1 {
+			as.Weight = weightConsts[index].value
+		}
+	}
+
+	if as.Stretch == 0 {
+		if index := stringContainsConst(additionalStyle, stretchStrings[:]); index != -1 {
+			as.Stretch = stretchConsts[index].value
+		}
+	}
+}
+
+// replace unspecified values by the default values: StyleNormal, WeightNormal, StretchNormal
+func (as *Aspect) setDefaults() {
+	if as.Style == 0 {
+		as.Style = StyleNormal
+	}
+
+	if as.Stretch == 0 {
+		as.Stretch = StretchNormal
+	}
+
+	if as.Weight == 0 {
+		as.Weight = WeightNormal
+	}
+}
+
+func (fd *fontDescriptor) additionalStyle() string {
+	var style string
+	if fd.os2 != nil && fd.os2.FsSelection&256 != 0 {
+		style = fd.names.Name(namePreferredSubfamily)
+		if style == "" {
+			style = fd.names.Name(nameFontSubfamily)
+		}
+	} else {
+		style = fd.names.Name(nameWWSSubfamily)
+		if style == "" {
+			style = fd.names.Name(namePreferredSubfamily)
+		}
+		if style == "" {
+			style = fd.names.Name(nameFontSubfamily)
+		}
+	}
+	style = strings.TrimSpace(style)
+	return style
+}
+
+func (fd *fontDescriptor) rawAspect() Aspect {
+	var (
+		style   Style
+		weight  Weight
+		stretch Stretch
+	)
+
+	if fd.os2 != nil {
+		// We have an OS/2 table; use the `fsSelection' field.  Bit 9
+		// indicates an oblique font face.  This flag has been
+		// introduced in version 1.5 of the OpenType specification.
+		if fd.os2.FsSelection&(1<<9) != 0 || fd.os2.FsSelection&1 != 0 {
+			style = StyleItalic
+		}
+
+		weight = Weight(fd.os2.USWeightClass)
+
+		switch fd.os2.USWidthClass {
+		case 1:
+			stretch = StretchUltraCondensed
+		case 2:
+			stretch = StretchExtraCondensed
+		case 3:
+			stretch = StretchCondensed
+		case 4:
+			stretch = StretchSemiCondensed
+		case 5:
+			stretch = StretchNormal
+		case 6:
+			stretch = StretchSemiExpanded
+		case 7:
+			stretch = StretchExpanded
+		case 8:
+			stretch = StretchExtraExpanded
+		case 9:
+			stretch = StretchUltraExpanded
+		}
+
+	} else {
+		// this is an old Mac font, use the header field
+		if isItalic := fd.head.MacStyle&2 != 0; isItalic {
+			style = StyleItalic
+		}
+		if isBold := fd.head.MacStyle&1 != 0; isBold {
+			weight = WeightBold
+		}
+	}
+
+	return Aspect{style, weight, stretch}
+}
+
+var rp = strings.NewReplacer(" ", "", "\t", "")
+
+func normalizeFamily(s1 string) string { return rp.Replace(strings.ToLower(s1)) }
+
+// returns the index in `constants` of a constant contained in `str`,
+// or -1
+func stringContainsConst(str string, constants []string) int {
+	for i, c := range constants {
+		if strings.Contains(str, c) {
+			return i
+		}
+	}
+	return -1
+}

--- a/opentype/api/metadata/descriptor.go
+++ b/opentype/api/metadata/descriptor.go
@@ -1,0 +1,88 @@
+package metadata
+
+import (
+	"github.com/go-text/typesetting/opentype/api/font"
+	"github.com/go-text/typesetting/opentype/loader"
+	"github.com/go-text/typesetting/opentype/tables"
+)
+
+const (
+	_ tables.NameID = iota
+	nameFontFamily
+	nameFontSubfamily
+	_
+	_
+	_
+	_
+	_
+	_
+	_
+	_
+	_
+	_
+	_
+	_
+	_
+	namePreferredFamily    // or Typographic Family
+	namePreferredSubfamily // or Typographic Subfamily
+	_
+	_
+	_
+	nameWWSFamily
+	nameWWSSubfamily
+)
+
+type fontDescriptor struct {
+	// these tables are required both in Family
+	// and Aspect
+	os2   *tables.Os2 // optional
+	names tables.Name
+	head  tables.Head
+}
+
+func newFontDescriptor(ld *loader.Loader) *fontDescriptor {
+	var out fontDescriptor
+
+	// load tables, all considered optional
+	raw, _ := ld.RawTable(loader.MustNewTag("OS/2"))
+	if os2, _, err := tables.ParseOs2(raw); err != nil {
+		out.os2 = &os2
+	}
+
+	raw, _ = ld.RawTable(loader.MustNewTag("name"))
+	out.names, _, _ = tables.ParseName(raw)
+
+	out.head, _ = font.LoadHeadTable(ld)
+
+	return &out
+}
+
+func (fd *fontDescriptor) family() string {
+	var family string
+	if fd.os2 != nil && fd.os2.FsSelection&256 != 0 {
+		family = fd.names.Name(namePreferredFamily)
+		if family == "" {
+			family = fd.names.Name(nameFontFamily)
+		}
+	} else {
+		family = fd.names.Name(nameWWSFamily)
+		if family == "" {
+			family = fd.names.Name(namePreferredFamily)
+		}
+		if family == "" {
+			family = fd.names.Name(nameFontFamily)
+		}
+	}
+	return family
+}
+
+// Metadata queries the family and the aspect properties of the
+// font loaded under [font]
+func Metadata(font *loader.Loader) (aspect Aspect, family string) {
+	descriptor := newFontDescriptor(font)
+
+	aspect = descriptor.aspect()
+	family = descriptor.family()
+
+	return
+}

--- a/opentype/api/metadata/descriptor.go
+++ b/opentype/api/metadata/descriptor.go
@@ -7,29 +7,12 @@ import (
 )
 
 const (
-	_ tables.NameID = iota
-	nameFontFamily
-	nameFontSubfamily
-	_
-	_
-	_
-	_
-	_
-	_
-	_
-	_
-	_
-	_
-	_
-	_
-	_
-	namePreferredFamily    // or Typographic Family
-	namePreferredSubfamily // or Typographic Subfamily
-	_
-	_
-	_
-	nameWWSFamily
-	nameWWSSubfamily
+	nameFontFamily         tables.NameID = 1
+	nameFontSubfamily      tables.NameID = 2
+	namePreferredFamily    tables.NameID = 16 // or Typographic Family
+	namePreferredSubfamily tables.NameID = 17 // or Typographic Subfamily
+	nameWWSFamily          tables.NameID = 21 //
+	nameWWSSubfamily       tables.NameID = 22 //
 )
 
 type fontDescriptor struct {

--- a/opentype/api/metadata/descriptor_test.go
+++ b/opentype/api/metadata/descriptor_test.go
@@ -1,0 +1,42 @@
+package metadata
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	td "github.com/go-text/typesetting-utils/opentype"
+	"github.com/go-text/typesetting/opentype/loader"
+	tu "github.com/go-text/typesetting/opentype/testutils"
+)
+
+func TestMetadata(t *testing.T) {
+	tests := []struct {
+		fontPath string
+		aspect   Aspect
+		family   string
+	}{
+		{
+			"common/Roboto-BoldItalic.ttf",
+			Aspect{StyleItalic, WeightBold, StretchNormal},
+			"Roboto",
+		},
+		{
+			"common/NotoSansArabic.ttf",
+			Aspect{StyleNormal, WeightNormal, StretchNormal},
+			"Noto Sans Arabic",
+		},
+	}
+
+	for _, test := range tests {
+		f, err := td.Files.ReadFile(test.fontPath)
+		tu.AssertNoErr(t, err)
+
+		ld, err := loader.NewLoader(bytes.NewReader(f))
+		tu.AssertNoErr(t, err)
+
+		gotAspect, gotFamily := Metadata(ld)
+		tu.AssertC(t, gotAspect == test.aspect, fmt.Sprint(gotAspect))
+		tu.AssertC(t, gotFamily == test.family, gotFamily)
+	}
+}

--- a/opentype/tables/head_gen.go
+++ b/opentype/tables/head_gen.go
@@ -24,7 +24,7 @@ func (item *Head) mustParse(src []byte) {
 	item.YMin = int16(binary.BigEndian.Uint16(src[38:]))
 	item.XMax = int16(binary.BigEndian.Uint16(src[40:]))
 	item.YMax = int16(binary.BigEndian.Uint16(src[42:]))
-	item.macStyle = binary.BigEndian.Uint16(src[44:])
+	item.MacStyle = binary.BigEndian.Uint16(src[44:])
 	item.lowestRecPPEM = binary.BigEndian.Uint16(src[46:])
 	item.fontDirectionHint = int16(binary.BigEndian.Uint16(src[48:]))
 	item.IndexToLocFormat = int16(binary.BigEndian.Uint16(src[50:]))

--- a/opentype/tables/head_src.go
+++ b/opentype/tables/head_src.go
@@ -19,7 +19,7 @@ type Head struct {
 	YMin               int16
 	XMax               int16
 	YMax               int16
-	macStyle           uint16
+	MacStyle           uint16
 	lowestRecPPEM      uint16
 	fontDirectionHint  int16
 	IndexToLocFormat   int16

--- a/opentype/tables/name_src.go
+++ b/opentype/tables/name_src.go
@@ -2,6 +2,39 @@
 
 package tables
 
+import (
+	"encoding/binary"
+	"unicode/utf16"
+)
+
+const (
+	PlatformUnicode PlatformID = iota
+	PlatformMac
+	PlatformIso // deprecated
+	PlatformMicrosoft
+	PlatformCustom
+	_
+	_
+	PlatformAdobe // artificial
+)
+
+const (
+	PEUnicodeDefault     = EncodingID(0)
+	PEUnicodeBMP         = EncodingID(3)
+	PEUnicodeFull        = EncodingID(4)
+	PEUnicodeFull13      = EncodingID(6)
+	PEMacRoman           = PEUnicodeDefault
+	PEMicrosoftSymbolCs  = EncodingID(0)
+	PEMicrosoftUnicodeCs = EncodingID(1)
+	PEMicrosoftUcs4      = EncodingID(10)
+)
+
+const (
+	plMacEnglish       = LanguageID(0)
+	plUnicodeDefault   = LanguageID(0)
+	plMicrosoftEnglish = LanguageID(0x0409)
+)
+
 // Naming table
 // See https://learn.microsoft.com/en-us/typography/opentype/spec/name
 type Name struct {
@@ -18,4 +51,132 @@ type nameRecord struct {
 	nameID       NameID
 	length       uint16
 	stringOffset uint16
+}
+
+// selectRecord return the entry for `name` or nil if not found.
+func (names Name) selectRecord(name NameID) *nameRecord {
+	var (
+		foundAppleRoman   = -1
+		foundAppleEnglish = -1
+		foundWin          = -1
+		foundUnicode      = -1
+		isEnglish         = false
+	)
+
+	for n, rec := range names.nameRecords {
+		// According to the OpenType 1.3 specification, only Microsoft or
+		// Apple platform IDs might be used in the `name' table.  The
+		// `Unicode' platform is reserved for the `cmap' table, and the
+		// `ISO' one is deprecated.
+		//
+		// However, the Apple TrueType specification doesn't say the same
+		// thing and goes to suggest that all Unicode `name' table entries
+		// should be coded in UTF-16.
+		if rec.nameID == name && rec.length > 0 {
+			switch rec.platformID {
+			case PlatformUnicode, PlatformIso:
+				// there is `languageID' to check there.  We should use this
+				// field only as a last solution when nothing else is
+				// available.
+				foundUnicode = n
+			case PlatformMac:
+				// This is a bit special because some fonts will use either
+				// an English language id, or a Roman encoding id, to indicate
+				// the English version of its font name.
+				if rec.languageID == plMacEnglish {
+					foundAppleEnglish = n
+				} else if rec.encodingID == PEMacRoman {
+					foundAppleRoman = n
+				}
+			case PlatformMicrosoft:
+				// we only take a non-English name when there is nothing
+				// else available in the font
+				if foundWin == -1 || (rec.languageID&0x3FF) == 0x009 {
+					switch rec.encodingID {
+					case PEMicrosoftSymbolCs, PEMicrosoftUnicodeCs, PEMicrosoftUcs4:
+						isEnglish = (rec.languageID & 0x3FF) == 0x009
+						foundWin = n
+					}
+				}
+			}
+		}
+	}
+
+	foundApple := foundAppleRoman
+	if foundAppleEnglish >= 0 {
+		foundApple = foundAppleEnglish
+	}
+
+	// some fonts contain invalid Unicode or Macintosh formatted entries;
+	// we will thus favor names encoded in Windows formats if available
+	// (provided it is an English name)
+	if foundWin >= 0 && !(foundApple >= 0 && !isEnglish) {
+		return &names.nameRecords[foundWin]
+	} else if foundApple >= 0 {
+		return &names.nameRecords[foundApple]
+	} else if foundUnicode >= 0 {
+		return &names.nameRecords[foundUnicode]
+	}
+	return nil
+}
+
+// Name returns the entry at [name], encoded in UTF-8 when possible,
+// or an empty string if not found
+func (names Name) Name(name NameID) string {
+	if record := names.selectRecord(name); record != nil {
+		return names.decodeRecord(*record)
+	}
+	return ""
+}
+
+// decode is a best-effort attempt to get an UTF-8 encoded version of
+// Value. Only MicrosoftUnicode (3,1 ,X), MacRomain (1,0,X) and Unicode platform
+// strings are supported.
+func (names Name) decodeRecord(n nameRecord) string {
+	end := int(n.stringOffset) + int(n.length)
+	if end > len(names.stringData) {
+		// invalid record
+		return ""
+	}
+	value := names.stringData[n.stringOffset:end]
+
+	if n.platformID == PlatformUnicode || (n.platformID == PlatformMicrosoft &&
+		n.encodingID == PEMicrosoftUnicodeCs) {
+		return decodeUtf16(value)
+	}
+
+	if n.platformID == PlatformMac && n.encodingID == PEMacRoman {
+		return DecodeMacintosh(value)
+	}
+
+	// no encoding detected, hope for utf8
+	return string(value)
+}
+
+// decode a big ending, no BOM utf16 string
+func decodeUtf16(b []byte) string {
+	ints := make([]uint16, len(b)/2)
+	for i := range ints {
+		ints[i] = binary.BigEndian.Uint16(b[2*i:])
+	}
+	return string(utf16.Decode(ints))
+}
+
+// Support for the old macintosh encoding
+
+var macintoshEncoding = [256]rune{
+	0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 196, 197, 199, 201, 209, 214, 220, 225, 224, 226, 228, 227, 229, 231, 233, 232, 234, 235, 237, 236, 238, 239, 241, 243, 242, 244, 246, 245, 250, 249, 251, 252, 8224, 176, 162, 163, 167, 8226, 182, 223, 174, 169, 8482, 180, 168, 8800, 198, 216, 8734, 177, 8804, 8805, 165, 181, 8706, 8721, 8719, 960, 8747, 170, 186, 937, 230, 248, 191, 161, 172, 8730, 402, 8776, 8710, 171, 187, 8230, 160, 192, 195, 213, 338, 339, 8211, 8212, 8220, 8221, 8216, 8217, 247, 9674, 255, 376, 8260, 8364,
+	8249, 8250, 64257, 64258, 8225, 183, 8218, 8222, 8240, 194, 202, 193, 203, 200, 205, 206, 207, 204, 211, 212, 63743, 210, 218, 219, 217, 305, 710, 732, 175, 728, 729, 730, 184, 733, 731, 711,
+}
+
+// DecodeMacintoshByte returns the rune for the given byte
+func DecodeMacintoshByte(b byte) rune { return macintoshEncoding[b] }
+
+// DecodeMacintosh decode a Macintosh encoded string
+func DecodeMacintosh(encoded []byte) string {
+	out := make([]rune, len(encoded))
+	for i, b := range encoded {
+		out[i] = macintoshEncoding[b]
+	}
+	return string(out)
 }

--- a/opentype/tables/name_test.go
+++ b/opentype/tables/name_test.go
@@ -1,0 +1,114 @@
+package tables
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	td "github.com/go-text/typesetting-utils/opentype"
+	"github.com/go-text/typesetting/opentype/loader"
+	"github.com/go-text/typesetting/opentype/testutils"
+	tu "github.com/go-text/typesetting/opentype/testutils"
+)
+
+func TestEncodings(t *testing.T) {
+	utf16s := []struct {
+		encoded []byte
+		decoded string
+	}{
+		{[]byte{0, 66, 0, 111, 0, 108, 0, 100}, "Bold"},
+		{[]byte{0, 82, 0, 111, 0, 98, 0, 111, 0, 116, 0, 111}, "Roboto"},
+		{[]byte{0, 82, 0, 101, 0, 103, 0, 117, 0, 108, 0, 97, 0, 114}, "Regular"},
+		{[]byte{0, 79, 0, 98, 0, 108, 0, 105, 0, 113, 0, 117, 0, 101}, "Oblique"},
+		{[]byte{0, 84, 0, 101, 0, 115, 0, 116, 0, 32, 0, 84, 0, 84, 0, 70}, "Test TTF"},
+		{[]byte{0, 79, 0, 112, 0, 101, 0, 110, 0, 32, 0, 83, 0, 97, 0, 110, 0, 115}, "Open Sans"},
+		{[]byte{0, 66, 0, 111, 0, 108, 0, 100, 0, 32, 0, 73, 0, 116, 0, 97, 0, 108, 0, 105, 0, 99}, "Bold Italic"},
+		{[]byte{0, 66, 0, 111, 0, 108, 0, 100, 0, 32, 0, 79, 0, 98, 0, 108, 0, 105, 0, 113, 0, 117, 0, 101}, "Bold Oblique"},
+		{[]byte{0, 82, 0, 97, 0, 108, 0, 101, 0, 119, 0, 97, 0, 121, 0, 45, 0, 118, 0, 52, 0, 48, 0, 50, 0, 48}, "Raleway-v4020"},
+		{[]byte{0, 79, 0, 108, 0, 100, 0, 97, 0, 110, 0, 105, 0, 97, 0, 32, 0, 65, 0, 68, 0, 70, 0, 32, 0, 83, 0, 116, 0, 100}, "Oldania ADF Std"},
+		{[]byte{0, 78, 0, 111, 0, 116, 0, 111, 0, 32, 0, 83, 0, 97, 0, 110, 0, 115, 0, 32, 0, 67, 0, 74, 0, 75, 0, 32, 0, 74, 0, 80}, "Noto Sans CJK JP"},
+		{[]byte{0, 78, 0, 111, 0, 116, 0, 111, 0, 32, 0, 83, 0, 97, 0, 110, 0, 115, 0, 32, 0, 67, 0, 74, 0, 75, 0, 32, 0, 75, 0, 82}, "Noto Sans CJK KR"},
+		{[]byte{0, 78, 0, 111, 0, 116, 0, 111, 0, 32, 0, 83, 0, 97, 0, 110, 0, 115, 0, 32, 0, 67, 0, 74, 0, 75, 0, 32, 0, 83, 0, 67}, "Noto Sans CJK SC"},
+		{[]byte{0, 78, 0, 111, 0, 116, 0, 111, 0, 32, 0, 83, 0, 97, 0, 110, 0, 115, 0, 32, 0, 67, 0, 74, 0, 75, 0, 32, 0, 84, 0, 67}, "Noto Sans CJK TC"},
+		{[]byte{0, 78, 0, 111, 0, 116, 0, 111, 0, 32, 0, 83, 0, 97, 0, 110, 0, 115, 0, 32, 0, 67, 0, 74, 0, 75, 0, 32, 0, 72, 0, 75}, "Noto Sans CJK HK"},
+		{[]byte{0, 78, 0, 111, 0, 116, 0, 111, 0, 32, 0, 83, 0, 101, 0, 114, 0, 105, 0, 102, 0, 32, 0, 67, 0, 74, 0, 75, 0, 32, 0, 74, 0, 80}, "Noto Serif CJK JP"},
+		{[]byte{0, 78, 0, 111, 0, 116, 0, 111, 0, 32, 0, 83, 0, 101, 0, 114, 0, 105, 0, 102, 0, 32, 0, 67, 0, 74, 0, 75, 0, 32, 0, 75, 0, 82}, "Noto Serif CJK KR"},
+		{[]byte{0, 78, 0, 111, 0, 116, 0, 111, 0, 32, 0, 83, 0, 101, 0, 114, 0, 105, 0, 102, 0, 32, 0, 67, 0, 74, 0, 75, 0, 32, 0, 83, 0, 67}, "Noto Serif CJK SC"},
+		{[]byte{0, 78, 0, 111, 0, 116, 0, 111, 0, 32, 0, 83, 0, 101, 0, 114, 0, 105, 0, 102, 0, 32, 0, 67, 0, 74, 0, 75, 0, 32, 0, 84, 0, 67}, "Noto Serif CJK TC"},
+		{[]byte{0, 78, 0, 111, 0, 116, 0, 111, 0, 32, 0, 83, 0, 97, 0, 110, 0, 115, 0, 32, 0, 77, 0, 111, 0, 110, 0, 111, 0, 32, 0, 67, 0, 74, 0, 75, 0, 32, 0, 74, 0, 80}, "Noto Sans Mono CJK JP"},
+		{[]byte{0, 78, 0, 111, 0, 116, 0, 111, 0, 32, 0, 83, 0, 97, 0, 110, 0, 115, 0, 32, 0, 77, 0, 111, 0, 110, 0, 111, 0, 32, 0, 67, 0, 74, 0, 75, 0, 32, 0, 75, 0, 82}, "Noto Sans Mono CJK KR"},
+		{[]byte{0, 78, 0, 111, 0, 116, 0, 111, 0, 32, 0, 83, 0, 97, 0, 110, 0, 115, 0, 32, 0, 77, 0, 111, 0, 110, 0, 111, 0, 32, 0, 67, 0, 74, 0, 75, 0, 32, 0, 83, 0, 67}, "Noto Sans Mono CJK SC"},
+		{[]byte{0, 78, 0, 111, 0, 116, 0, 111, 0, 32, 0, 83, 0, 97, 0, 110, 0, 115, 0, 32, 0, 77, 0, 111, 0, 110, 0, 111, 0, 32, 0, 67, 0, 74, 0, 75, 0, 32, 0, 84, 0, 67}, "Noto Sans Mono CJK TC"},
+		{[]byte{0, 78, 0, 111, 0, 116, 0, 111, 0, 32, 0, 83, 0, 97, 0, 110, 0, 115, 0, 32, 0, 77, 0, 111, 0, 110, 0, 111, 0, 32, 0, 67, 0, 74, 0, 75, 0, 32, 0, 72, 0, 75}, "Noto Sans Mono CJK HK"},
+	}
+	for _, utf16 := range utf16s {
+		testutils.Assert(t, decodeUtf16(utf16.encoded) == utf16.decoded)
+	}
+
+	macs := []struct {
+		encoded []byte
+		decoded string
+	}{
+		{[]byte{67, 111, 117, 114, 105, 101, 114}, "Courier"},
+		{[]byte{71, 101, 110, 101, 118, 97}, "Geneva"},
+	}
+	for _, mac := range macs {
+		testutils.Assert(t, DecodeMacintosh(mac.encoded) == mac.decoded)
+	}
+
+	testutils.Assert(t, DecodeMacintoshByte(71) == 'G')
+}
+
+func TestFamilyNames(t *testing.T) {
+	// macintosh encoding
+
+	f, err := td.Files.ReadFile("collections/Courier.dfont")
+	tu.AssertNoErr(t, err)
+
+	fonts, err := loader.NewLoaders(bytes.NewReader(f))
+	tu.AssertC(t, err == nil, "Courier")
+
+	for _, font := range fonts {
+		names, _, err := ParseName(readTable(t, font, "name"))
+		tu.AssertNoErr(t, err)
+
+		// NameFontFamily
+		tu.Assert(t, names.Name(1) == "Courier")
+	}
+
+	// UTF16 encoding
+	f, err = td.Files.ReadFile("collections/NotoSansCJK-Bold.ttc")
+	tu.AssertNoErr(t, err)
+
+	fonts, err = loader.NewLoaders(bytes.NewReader(f))
+	tu.AssertC(t, err == nil, "NotoSansCJK")
+
+	for _, font := range fonts {
+		names, _, err := ParseName(readTable(t, font, "name"))
+		tu.AssertNoErr(t, err)
+
+		// NameFontFamily
+		tu.Assert(t, strings.HasPrefix(names.Name(1), "Noto Sans"))
+	}
+
+	font := readFontFile(t, "common/Roboto-BoldItalic.ttf")
+	names, _, err := ParseName(readTable(t, font, "name"))
+	tu.AssertNoErr(t, err)
+	// NameFontFamily
+	tu.Assert(t, names.Name(1) == "Roboto")
+}
+
+func TestNames(t *testing.T) {
+	for _, filename := range tu.Filenames(t, "common") {
+		fp := readFontFile(t, filename)
+		names, _, err := ParseName(readTable(t, fp, "name"))
+		tu.AssertNoErr(t, err)
+
+		for _, rec := range names.nameRecords {
+			tu.Assert(t, names.Name(rec.nameID) != "")
+		}
+
+		tu.Assert(t, names.selectRecord(0xFFFF) == nil)
+		tu.Assert(t, names.Name(0xFFFF) == "")
+	}
+}

--- a/opentype/tables/name_test.go
+++ b/opentype/tables/name_test.go
@@ -7,7 +7,6 @@ import (
 
 	td "github.com/go-text/typesetting-utils/opentype"
 	"github.com/go-text/typesetting/opentype/loader"
-	"github.com/go-text/typesetting/opentype/testutils"
 	tu "github.com/go-text/typesetting/opentype/testutils"
 )
 
@@ -42,7 +41,7 @@ func TestEncodings(t *testing.T) {
 		{[]byte{0, 78, 0, 111, 0, 116, 0, 111, 0, 32, 0, 83, 0, 97, 0, 110, 0, 115, 0, 32, 0, 77, 0, 111, 0, 110, 0, 111, 0, 32, 0, 67, 0, 74, 0, 75, 0, 32, 0, 72, 0, 75}, "Noto Sans Mono CJK HK"},
 	}
 	for _, utf16 := range utf16s {
-		testutils.Assert(t, decodeUtf16(utf16.encoded) == utf16.decoded)
+		tu.Assert(t, decodeUtf16(utf16.encoded) == utf16.decoded)
 	}
 
 	macs := []struct {
@@ -53,10 +52,10 @@ func TestEncodings(t *testing.T) {
 		{[]byte{71, 101, 110, 101, 118, 97}, "Geneva"},
 	}
 	for _, mac := range macs {
-		testutils.Assert(t, DecodeMacintosh(mac.encoded) == mac.decoded)
+		tu.Assert(t, DecodeMacintosh(mac.encoded) == mac.decoded)
 	}
 
-	testutils.Assert(t, DecodeMacintoshByte(71) == 'G')
+	tu.Assert(t, DecodeMacintoshByte(71) == 'G')
 }
 
 func TestFamilyNames(t *testing.T) {

--- a/opentype/tables/tables.go
+++ b/opentype/tables/tables.go
@@ -48,8 +48,7 @@ type PlatformID uint16
 // The most common values are provided as constants.
 type EncodingID uint16
 
-// LanguageID represents the language used by an entry in the name table,
-// the three most common values are provided as constants.
+// LanguageID represents the language used by an entry in the name table
 type LanguageID uint16
 
 // Offset16 is an offset into the input byte slice


### PR DESCRIPTION
This PR provides a way to query metadata about a font (see also #49)

The changes are large because some code has moved to the `tables` package to avoid duplication.

The various constants are taken from the CSS specifications (also used by other librairies like font-kit).

For now, the API requires a `*loader.Loader`,  meaning the original font file is needed. This is required since the `*font.Font` type does not store all the metadata, it only selects the shaping/glyph related information.