### PR TITLE
shaping: add lru font cache and benchmark impact

### DIFF
--- a/shaping/lru.go
+++ b/shaping/lru.go
@@ -1,0 +1,69 @@
+package shaping
+
+import (
+	"github.com/go-text/typesetting/harfbuzz"
+	"github.com/go-text/typesetting/opentype/api/font"
+)
+
+// fontEntry holds a single key-value pair for an LRU cache.
+type fontEntry struct {
+	next, prev *fontEntry
+	key        *font.Font
+	v          *harfbuzz.Font
+}
+
+// fontLRU is a least-recently-used cache for harfbuzz fonts built from
+// font.Fonts. It uses a doubly-linked list to track how recently elements have
+// been used and a map to store element data for quick access.
+type fontLRU struct {
+	// This implementation is derived from the one here under the terms of the UNLICENSE:
+	//
+	// https://git.sr.ht/~eliasnaur/gio/tree/e768fe347a732056031100f2c66987d6db258ea4/item/text/lru.go
+	m          map[*font.Font]*fontEntry
+	head, tail *fontEntry
+	maxSize    int
+}
+
+// Get fetches the value associated with the given key, if any.
+func (l *fontLRU) Get(k *font.Font) (*harfbuzz.Font, bool) {
+	if lt, ok := l.m[k]; ok {
+		l.remove(lt)
+		l.insert(lt)
+		return lt.v, true
+	}
+	return nil, false
+}
+
+// Put inserts the given value with the given key, evicting old
+// cache entries if necessary.
+func (l *fontLRU) Put(k *font.Font, v *harfbuzz.Font) {
+	if l.m == nil {
+		l.m = make(map[*font.Font]*fontEntry)
+		l.head = new(fontEntry)
+		l.tail = new(fontEntry)
+		l.head.prev = l.tail
+		l.tail.next = l.head
+	}
+	val := &fontEntry{key: k, v: v}
+	l.m[k] = val
+	l.insert(val)
+	if len(l.m) > l.maxSize {
+		oldest := l.tail.next
+		l.remove(oldest)
+		delete(l.m, oldest.key)
+	}
+}
+
+// remove cuts e out of the lru linked list.
+func (l *fontLRU) remove(e *fontEntry) {
+	e.next.prev = e.prev
+	e.prev.next = e.next
+}
+
+// insert adds e to the lru linked list.
+func (l *fontLRU) insert(e *fontEntry) {
+	e.next = l.head
+	e.prev = l.head.prev
+	e.prev.next = e
+	e.next.prev = e
+}

--- a/shaping/shaping_test.go
+++ b/shaping/shaping_test.go
@@ -205,25 +205,29 @@ func TestCountClusters(t *testing.T) {
 func BenchmarkShaping(b *testing.B) {
 	for _, langInfo := range benchLangs {
 		for _, size := range []int{10, 100, 1000} {
-			b.Run(fmt.Sprintf("%drunes-%s", size, langInfo.name), func(b *testing.B) {
-				input := Input{
-					Text:      langInfo.text[:size],
-					RunStart:  0,
-					RunEnd:    size,
-					Direction: langInfo.dir,
-					Face:      langInfo.face,
-					Size:      16 * 72,
-					Script:    langInfo.script,
-					Language:  langInfo.lang,
-				}
-				var shaper HarfbuzzShaper
-				var out Output
-				b.ResetTimer()
-				for i := 0; i < b.N; i++ {
-					out = shaper.Shape(input)
-				}
-				_ = out
-			})
+			for _, cacheSize := range []int{0, 5} {
+
+				b.Run(fmt.Sprintf("%drunes-%s-%dfontCache", size, langInfo.name, cacheSize), func(b *testing.B) {
+					input := Input{
+						Text:      langInfo.text[:size],
+						RunStart:  0,
+						RunEnd:    size,
+						Direction: langInfo.dir,
+						Face:      langInfo.face,
+						Size:      16 * 72,
+						Script:    langInfo.script,
+						Language:  langInfo.lang,
+					}
+					var shaper HarfbuzzShaper
+					shaper.SetFontCacheSize(cacheSize)
+					var out Output
+					b.ResetTimer()
+					for i := 0; i < b.N; i++ {
+						out = shaper.Shape(input)
+					}
+					_ = out
+				})
+			}
 		}
 	}
 }


### PR DESCRIPTION
This commit restructures the font cache within the HarfbuzzShaper type to function as an LRU cache with a configurable size, and it also updates the shaping benchmark to measure the performance impact of the cache. For small bodies of text, initial benchmark results suggest substantial performance improvements for complex scripts (and complex fonts) and marginal gains for simpler scripts like latin.

```
$ go test -run '^$' -bench Shaping -benchmem ./shaping/ goos: linux
goarch: amd64
pkg: github.com/go-text/typesetting/shaping
cpu: Intel(R) Core(TM) i7-6700K CPU @ 4.00GHz
BenchmarkShaping/10runes-arabic-0fontCache-8                7610            152486 ns/op           70570 B/op       1363 allocs/op
BenchmarkShaping/10runes-arabic-5fontCache-8               40285             29687 ns/op            7418 B/op        140 allocs/op
BenchmarkShaping/100runes-arabic-0fontCache-8               2629            445300 ns/op          139638 B/op       3339 allocs/op
BenchmarkShaping/100runes-arabic-5fontCache-8               3468            321211 ns/op           76501 B/op       2116 allocs/op
BenchmarkShaping/1000runes-arabic-0fontCache-8               357           3290018 ns/op          878659 B/op      24568 allocs/op
BenchmarkShaping/1000runes-arabic-5fontCache-8               375           3155476 ns/op          815639 B/op      23348 allocs/op
BenchmarkShaping/10runes-latin-0fontCache-8               436546              2617 ns/op            2288 B/op          9 allocs/op
BenchmarkShaping/10runes-latin-5fontCache-8               436644              2472 ns/op            2176 B/op          7 allocs/op
BenchmarkShaping/100runes-latin-0fontCache-8               71804             16676 ns/op            8176 B/op          9 allocs/op
BenchmarkShaping/100runes-latin-5fontCache-8               72498             16368 ns/op            8064 B/op          7 allocs/op
BenchmarkShaping/1000runes-latin-0fontCache-8               6877            158386 ns/op           67213 B/op          9 allocs/op
BenchmarkShaping/1000runes-latin-5fontCache-8               7297            156329 ns/op           67100 B/op          7 allocs/op
```