### PR TITLE
[language] avoid potential crash on invalid (non ASCII) language tags

### DIFF
--- a/language/language.go
+++ b/language/language.go
@@ -27,8 +27,11 @@ type Language string
 // than letters, numbers and '-'.
 func NewLanguage(language string) Language {
 	out := make([]byte, 0, len(language))
-	for _, b := range language {
-		can := canonMap[b]
+	for _, r := range language {
+		if r >= 0xFF {
+			continue
+		}
+		can := canonMap[r]
 		if can != 0 {
 			out = append(out, can)
 		}

--- a/language/language_test.go
+++ b/language/language_test.go
@@ -10,6 +10,13 @@ func TestLanguage(t *testing.T) {
 	fmt.Println(DefaultLanguage())
 }
 
+func TestNonASCIILanguage(t *testing.T) {
+	_ = NewLanguage("Δ") // should not panic
+	if l1, l2 := NewLanguage("aΔ"), NewLanguage("a"); l1 != l2 {
+		t.Fatalf("unexpected handling of non ASCII tags: %s != %s", l1, l2)
+	}
+}
+
 func TestSimpleInheritance(t *testing.T) {
 	l := NewLanguage("en_US_someVariant")
 	if sh := l.SimpleInheritance(); !reflect.DeepEqual(sh, []Language{l, "en-us", "en"}) {


### PR DESCRIPTION
Fix for the issue raised by @andydotxyz at https://github.com/go-text/typesetting-utils/pull/9