### PR TITLE
Readability enhancements for line wrapping

### DIFF
--- a/shaping/fuzz_test.go
+++ b/shaping/fuzz_test.go
@@ -19,7 +19,7 @@ func FuzzE2E(f *testing.F) {
 	f.Fuzz(func(t *testing.T, input string) {
 		textInput := []rune(input)
 		var shaper HarfbuzzShaper
-		out := shaper.Shape(Input{
+		out := []Output{shaper.Shape(Input{
 			Text:      textInput,
 			RunStart:  0,
 			RunEnd:    len(textInput),
@@ -28,12 +28,12 @@ func FuzzE2E(f *testing.F) {
 			Size:      16 * 72,
 			Script:    language.Arabic,
 			Language:  language.NewLanguage("AR"),
-		})
-		if out.Runes.Count != len(textInput) {
-			t.Errorf("expected %d shaped runes, got %d", len(textInput), out.Runes.Count)
+		})}
+		if out[0].Runes.Count != len(textInput) {
+			t.Errorf("expected %d shaped runes, got %d", len(textInput), out[0].Runes.Count)
 		}
 		var l LineWrapper
-		outs, _ := l.WrapParagraph(WrapConfig{}, 100, textInput, NewSliceIterator(out))
+		outs, _ := l.WrapParagraph(WrapConfig{}, 100, textInput, NewSliceIterator(out), nil)
 		totalRunes := 0
 		for _, l := range outs {
 			for _, run := range l {

--- a/shaping/wrapping_test.go
+++ b/shaping/wrapping_test.go
@@ -1716,6 +1716,35 @@ func TestWrappingTruncation(t *testing.T) {
 	}
 }
 
+func TestWrapping_oneLine(t *testing.T) {
+	textInput := []rune("Lorem ipsum") // a simple input that fits on one line
+	face := benchEnFace
+	var shaper HarfbuzzShaper
+	out := []Output{shaper.Shape(Input{
+		Text:      textInput,
+		RunStart:  0,
+		RunEnd:    len(textInput),
+		Direction: di.DirectionLTR,
+		Face:      face,
+		Size:      fixed.I(16),
+		Script:    language.Latin,
+		Language:  language.NewLanguage("EN"),
+	})}
+	iter := NewSliceIterator(out)
+	var l LineWrapper
+
+	outs, _ := l.WrapParagraph(WrapConfig{}, 250, textInput, iter, nil)
+	if len(outs) != 1 {
+		t.Errorf("expected one line, got %d", len(outs))
+	}
+
+	// the run in iter should have been consumed
+	outs, _ = l.WrapParagraph(WrapConfig{}, 250, textInput, iter, nil)
+	if len(outs) != 0 {
+		t.Errorf("expected no line, got %d", len(outs))
+	}
+}
+
 // TestWrappingTruncation checks that the line wrapper's truncation features
 // handle some edge cases.
 func TestWrappingTruncationEdgeCases(t *testing.T) {


### PR DESCRIPTION
This PR is against the `iterator` branch (the base of #68) instead of `main`. The reason I've separated it out is that I didn't want to put an overwhelming quantity of change into #68, but this work does depend on the changes in that branch.

These changes are motivated by wanting to introduce wrapping on grapheme cluster boundaries as well as "word" boundaries (what we do right now). I needed to reorganize our logic some in order to achieve that, so I was simply trying to refactor so that I could reuse appropriate logic and make things more readable. I did _not_ expect a significant speedup from this refactor, but...

```
                                      │ with-scratch.txt │        after-refactor.txt         │
                                      │      sec/op      │   sec/op     vs base              │
Wrapping/10runes-arabic-1parts-8             31.39n ± 4%   28.78n ± 2%  -8.33% (p=0.002 n=6)
Wrapping/10runes-arabic-10parts-8            2.748µ ± 4%   2.551µ ± 0%  -7.20% (p=0.002 n=6)
Wrapping/100runes-arabic-1parts-8            18.66µ ± 3%   17.52µ ± 1%  -6.07% (p=0.002 n=6)
Wrapping/100runes-arabic-10parts-8           19.66µ ± 4%   18.22µ ± 1%  -7.30% (p=0.002 n=6)
Wrapping/100runes-arabic-100parts-8          36.90µ ± 3%   34.80µ ± 1%  -5.69% (p=0.002 n=6)
Wrapping/1000runes-arabic-1parts-8           185.1µ ± 4%   167.4µ ± 0%  -9.55% (p=0.002 n=6)
Wrapping/1000runes-arabic-10parts-8          184.0µ ± 3%   169.1µ ± 0%  -8.13% (p=0.002 n=6)
Wrapping/1000runes-arabic-100parts-8         191.4µ ± 3%   179.9µ ± 0%  -5.99% (p=0.002 n=6)
Wrapping/1000runes-arabic-1000parts-8        370.9µ ± 7%   356.4µ ± 1%  -3.92% (p=0.002 n=6)
Wrapping/10runes-latin-1parts-8              31.00n ± 2%   28.52n ± 3%  -7.98% (p=0.002 n=6)
Wrapping/10runes-latin-10parts-8             2.362µ ± 5%   2.139µ ± 0%  -9.46% (p=0.002 n=6)
Wrapping/100runes-latin-1parts-8             14.83µ ± 3%   13.90µ ± 0%  -6.28% (p=0.002 n=6)
Wrapping/100runes-latin-10parts-8            16.11µ ± 4%   14.94µ ± 1%  -7.27% (p=0.002 n=6)
Wrapping/100runes-latin-100parts-8           33.58µ ± 5%   31.66µ ± 2%  -5.73% (p=0.002 n=6)
Wrapping/1000runes-latin-1parts-8            149.2µ ± 5%   136.8µ ± 3%  -8.30% (p=0.002 n=6)
Wrapping/1000runes-latin-10parts-8           156.2µ ± 5%   141.9µ ± 1%  -9.17% (p=0.002 n=6)
Wrapping/1000runes-latin-100parts-8          169.1µ ± 3%   156.0µ ± 1%  -7.76% (p=0.002 n=6)
Wrapping/1000runes-latin-1000parts-8         357.7µ ± 4%   336.6µ ± 0%  -5.89% (p=0.002 n=6)
WrappingHappyPath-8                          30.37n ± 4%   28.02n ± 1%  -7.75% (p=0.002 n=6)
geomean                                      15.95µ        14.79µ       -7.26%
```

There are no changes at all to memory use or allocations.

Anyway, since this work depends on #68, and is logically somewhat distinct, I've opened it as a separate PR. I look forward to your review on both. :D