### PR TITLE
opentype/api/font: try to avoid extra allocations

### DIFF
--- a/opentype/api/font/renderer.go
+++ b/opentype/api/font/renderer.go
@@ -150,11 +150,16 @@ func midPoint(p, q api.SegmentPoint) api.SegmentPoint {
 
 // build the segments from the resolved contour points
 func buildSegments(points []contourPoint) []api.Segment {
+	if len(points) == 0 {
+		return nil
+	}
+
 	var (
 		firstOnCurveValid, firstOffCurveValid, lastOffCurveValid bool
 		firstOnCurve, firstOffCurve, lastOffCurve                api.SegmentPoint
-		out                                                      []api.Segment
 	)
+
+	out := make([]api.Segment, 0, len(points)+2)
 
 	for _, point := range points {
 		p := point.SegmentPoint

--- a/opentype/api/font/renderer_test.go
+++ b/opentype/api/font/renderer_test.go
@@ -228,6 +228,23 @@ func TestGlyfSegments1(t *testing.T) {
 	}
 }
 
+func BenchmarkBuildSegments(b *testing.B) {
+	var points []contourPoint
+	font := loadFont(b, "common/Roboto-BoldItalic.ttf")
+	face := Face{Font: font}
+	gid, ok := face.NominalGlyph('&')
+	if !ok {
+		b.Fatal("did not find & in the font")
+	}
+	face.getPointsForGlyph(uint16(gid), 0, &points)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_ = buildSegments(points)
+	}
+}
+
 func TestGlyfSegments2(t *testing.T) {
 	font := loadFont(t, "common/Roboto-BoldItalic.ttf")
 


### PR DESCRIPTION
Low hanging fruit in some performance.

The out slice was reallocated several times, we can use the length of contour points as a quick guess.

```
                   │ before.txt~ │             after.txt~              │
                   │   sec/op    │   sec/op     vs base                │
  BuildSegments-32   2.435µ ± 4%   1.367µ ± 2%  -43.87% (p=0.000 n=10)

                   │ before.txt~  │              after.txt~              │
                   │     B/op     │     B/op      vs base                │
  BuildSegments-32   3.484Ki ± 0%   1.750Ki ± 0%  -49.78% (p=0.000 n=10)

                   │ before.txt~ │             after.txt~             │
                   │  allocs/op  │ allocs/op   vs base                │
  BuildSegments-32    7.000 ± 0%   1.000 ± 0%  -85.71% (p=0.000 n=10)
```