### PR TITLE
Enable breaking lines within "words" by breaking on grapheme clusters

### DIFF
--- a/shaping/fuzz_test.go
+++ b/shaping/fuzz_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-text/typesetting/di"
 	"github.com/go-text/typesetting/language"
+	"github.com/go-text/typesetting/segmenter"
 )
 
 // FuzzE2E shapes and wraps large strings looking for unshapable text or failures
@@ -47,5 +48,50 @@ func FuzzE2E(f *testing.F) {
 			t.Errorf("mismatched runes! expected %d, but wrapped output only contains %d", len(textInput), totalRunes)
 		}
 		_ = outs
+	})
+}
+
+func FuzzBreakOptions(f *testing.F) {
+	f.Add(string([]rune{183067, 318808839, 476266048}))
+	f.Add(benchParagraphArabic)
+	f.Add(benchParagraphLatin)
+	f.Fuzz(func(t *testing.T, input string) {
+		runes := []rune(input)
+		breaker := newBreaker(&segmenter.Segmenter{}, runes)
+		var wordOptions []breakOption
+		for b, ok := breaker.nextWordBreak(); ok; b, ok = breaker.nextWordBreak() {
+			prevRuneIndex := 0
+			if len(wordOptions) > 0 {
+				prevRuneIndex = wordOptions[len(wordOptions)-1].breakAtRune + 1
+			}
+			segmentRunes := runes[prevRuneIndex : b.breakAtRune+1]
+			segmentGraphemes := []breakOption{}
+			for b, ok := breaker.nextGraphemeBreak(); ok; b, ok = breaker.nextGraphemeBreak() {
+				// Adjust break offset to be relative to the start of the segment.
+				b.breakAtRune -= prevRuneIndex
+				segmentGraphemes = append(segmentGraphemes, b)
+			}
+			seg := segmenter.Segmenter{}
+			seg.Init(segmentRunes)
+			correctGraphemes := []int{}
+			count := 0
+			for iter := seg.GraphemeIterator(); iter.Next(); {
+				g := iter.Grapheme()
+				breakAt := g.Offset + len(g.Text) - 1
+				firstGraphemeInText := prevRuneIndex == 0
+				if !firstGraphemeInText {
+					continue
+				}
+				count++
+				correctGraphemes = append(correctGraphemes, breakAt)
+			}
+			if count > 0 && len(segmentGraphemes) != count {
+				t.Errorf("runes[%d:%d] expected %d graphemes, got %d", prevRuneIndex, b.breakAtRune+1, count, len(segmentGraphemes))
+				t.Errorf("correct graphemes: %v\ngot graphemes: %v", correctGraphemes, segmentGraphemes)
+			}
+			checkOptions(t, segmentRunes, segmentGraphemes)
+			wordOptions = append(wordOptions, b)
+		}
+		checkOptions(t, runes, wordOptions)
 	})
 }

--- a/shaping/wrapping.go
+++ b/shaping/wrapping.go
@@ -613,7 +613,6 @@ func (w *wrapBuffer) reset() {
 	}
 }
 
-
 // singleRunParagraph is an optimized helper for quickly constructing
 // a []Line containing only a single run.
 func (w *wrapBuffer) singleRunParagraph(run Output) []Line {
@@ -881,10 +880,6 @@ func (l *LineWrapper) wrapNextLine(config lineConfig) (done bool) {
 		case fits:
 			l.scratch.markCandidateBest(candidateRun)
 			continue
-		case endIteration:
-			// The iterators are exhausted, use whatever we have.
-			l.scratch.markCandidateBest()
-			return true
 		case endLine:
 			// Found a valid line ending the text, append the candidateRun and use it.
 			l.scratch.markCandidateBest(candidateRun)
@@ -926,10 +921,6 @@ func (l *LineWrapper) wrapNextLine(config lineConfig) (done bool) {
 				l.scratch.markCandidateBest(candidateRun)
 				l.breaker.markWordOptionUnused()
 				continue
-			case endIteration:
-				// The iterators are exhausted, use whatever we have.
-				l.scratch.markCandidateBest()
-				return true
 			case endLine:
 				l.scratch.markCandidateBest(candidateRun)
 				return true
@@ -967,10 +958,6 @@ const (
 	// breakInvalid indicates that the provided break candidate is incompatible with the shaped
 	// text and should be skipped.
 	breakInvalid processBreakResult = iota
-	// endIteration indicates that there are no more possible runs in the iterators, but none of
-	// them are valid. The scratch buffer's candidate is filled with whatever text was read from
-	// the iterators before they ended.
-	endIteration
 	// endLine indicates that the candidate fits on the line and terminates the text.
 	endLine
 	// truncated indicates that the candidate does not fit on the line and that truncation needs to

--- a/shaping/wrapping.go
+++ b/shaping/wrapping.go
@@ -1,7 +1,6 @@
 package shaping
 
 import (
-	"fmt"
 	"sort"
 
 	"github.com/go-text/typesetting/di"
@@ -614,9 +613,6 @@ func (w *wrapBuffer) reset() {
 	}
 }
 
-func (w *wrapBuffer) stats() string {
-	return fmt.Sprintf("paragraph: %d(%d), line: %d(%d), used: %d, exhausted: %v, alt: %d(%d)", len(w.paragraph), cap(w.paragraph), len(w.line), cap(w.line), w.lineUsed, w.lineExhausted, len(w.alt), cap(w.alt))
-}
 
 // singleRunParagraph is an optimized helper for quickly constructing
 // a []Line containing only a single run.

--- a/shaping/wrapping_test.go
+++ b/shaping/wrapping_test.go
@@ -879,6 +879,18 @@ func TestWrapLine(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:      "simple fast-path",
+			shaped:    []Output{shapedText1},
+			paragraph: []rune(text1),
+			maxWidth:  200,
+			expected: []expected{
+				{
+					line: Line{shapedText1},
+					done: true,
+				},
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			var (

--- a/shaping/wrapping_test.go
+++ b/shaping/wrapping_test.go
@@ -2389,6 +2389,39 @@ func TestLineWrapperBreakPolicies(t *testing.T) {
 	}
 }
 
+// Checks that grapheme break in ligature are properly
+// avoided
+func TestGraphemeBreakLigature(t *testing.T) {
+	const text1 = "il est affable"
+	gls := append(
+		glyphs(0, 7),        // simple 1:1 mapping
+		ligatureGlyph(8, 2), // ligature
+		simpleGlyph(10),     // a
+		simpleGlyph(11),     // b
+		simpleGlyph(12),     // l
+		simpleGlyph(13),     // e
+	)
+	shapedText1 = Output{
+		Advance: fixed.I(10 * len(gls)),
+		Runes:   Range{Count: len([]rune(text1))},
+		Glyphs:  gls,
+		LineBounds: Bounds{
+			Ascent:  fixed.I(10),
+			Descent: fixed.I(5),
+			// No line gap.
+		},
+		GlyphBounds: Bounds{
+			Ascent: fixed.I(10),
+			// No glyphs descend.
+		},
+	}
+	var w LineWrapper
+	lines, _ := w.WrapParagraph(WrapConfig{BreakPolicy: Always}, 90, []rune(text1), NewSliceIterator([]Output{shapedText1}))
+	if L := lines[0][0].Runes.Count; L != 10 {
+		t.Errorf("invalid break with ligature %d", L)
+	}
+}
+
 func TestLineWrapperBreakSpecific(t *testing.T) {
 	type expectation struct {
 		name           string

--- a/shaping/wrapping_test.go
+++ b/shaping/wrapping_test.go
@@ -2198,6 +2198,10 @@ func TestCutRunInto(t *testing.T) {
 	}
 }
 
+func (w *wrapBuffer) stats() string {
+	return fmt.Sprintf("paragraph: %d(%d), line: %d(%d), used: %d, exhausted: %v, alt: %d(%d)", len(w.paragraph), cap(w.paragraph), len(w.line), cap(w.line), w.lineUsed, w.lineExhausted, len(w.alt), cap(w.alt))
+}
+
 func TestWrapBuffer(t *testing.T) {
 	t.Run("new and reset have same state", func(t *testing.T) {
 		b1 := wrapBuffer{}

--- a/shaping/wrapping_test.go
+++ b/shaping/wrapping_test.go
@@ -896,6 +896,13 @@ func TestWrapLine(t *testing.T) {
 				if done != expected.done {
 					t.Errorf("done mismatch! expected %v, got %v", expected.done, done)
 				}
+
+				if expected.done { // check WrapNextLine is now a no-op
+					line, _, done = l.WrapNextLine(200)
+					if line != nil || !done {
+						t.Errorf("expect nil output for WrapNextLine, got %p and %v", line, done)
+					}
+				}
 			}
 		})
 	}
@@ -1723,7 +1730,6 @@ func checkRuneCounts(t *testing.T, source []rune, lines []Line, truncated int) [
 				continue
 			}
 			if run.Runes.Offset != totalRunes {
-
 				t.Errorf("lines[%d][%d].Runes.Offset=%d, expected %d", lineIdx, runIdx, run.Runes.Offset, totalRunes)
 			}
 			totalRunes += run.Runes.Count


### PR DESCRIPTION
This commit implements wrapping on grapheme cluster boundaries (UAX#29) in addition to our previous word boundary (UAX#14) wrapping. The choice of whether to wrap on grapheme clusters is left up to a new LineBreakPolicy type with three options:

- WhenNecessary: This option will break using grapheme clusters when no word can fit on the line or when it is truncating a word (preserving as many grapheme clusters of the word as possible). This is the default policy.
- Always: This option will break on grapheme clusters whenever possible, fitting as many grapheme clusters as possible on every line.
- Never: This option disables the use of grapheme cluster breaking entirely, and preserves the prior behavior.

As WhenNecessary is the zero value of LineBreakPolicy, consumers of our API will experience a behavior change when updating to this version. Text that previously overflowed its bounds because words were too long will now fit within them. I think that this is going to be an improvement for 95% or more of use cases, so the change is warranted.

~This PR is a draft while its prerequisite, #68, is still under review.~
