### PR TITLE
[opentype] Check bitmap length for black and white format

### DIFF
--- a/opentype/api/font.go
+++ b/opentype/api/font.go
@@ -181,9 +181,15 @@ type BitmapFormat uint8
 
 const (
 	_ BitmapFormat = iota
+	// The [GlyphBitmap.Data] slice stores a black or white (0/1)
+	// bit image, whose length L satisfies
+	// L * 8 >= [GlyphBitmap.Width] * [GlyphBitmap.Height]
 	BlackAndWhite
+	// The [GlyphBitmap.Data] slice stores a PNG encoded image
 	PNG
+	// The [GlyphBitmap.Data] slice stores a JPG encoded image
 	JPG
+	// The [GlyphBitmap.Data] slice stores a TIFF encoded image
 	TIFF
 )
 

--- a/opentype/api/font/renderer.go
+++ b/opentype/api/font/renderer.go
@@ -12,8 +12,10 @@ import (
 	"github.com/go-text/typesetting/opentype/api"
 )
 
-var errEmptySbixTable = errors.New("empty 'sbix' table")
-var errEmptyBitmapTable = errors.New("empty bitmap table")
+var (
+	errEmptySbixTable   = errors.New("empty 'sbix' table")
+	errEmptyBitmapTable = errors.New("empty bitmap table")
+)
 
 // GlyphData returns the glyph content for [gid], or nil if
 // not found.
@@ -97,6 +99,11 @@ func (bt bitmap) glyphData(gid gID, xPpem, yPpem uint16) (api.GlyphBitmap, error
 		out.Format = api.PNG
 	case 2, 5:
 		out.Format = api.BlackAndWhite
+		// ensure data length
+		L := out.Width * out.Height // in bits
+		if len(out.Data)*8 < L {
+			return api.GlyphBitmap{}, fmt.Errorf("EOF in glyph bitmap: expected %d, got %d", L, len(out.Data)*8)
+		}
 	default:
 		return api.GlyphBitmap{}, fmt.Errorf("unsupported format %d in bitmap table", subtable.imageFormat)
 	}


### PR DESCRIPTION
This PR adds a check to make sure bitmap access in the renderer (https://github.com/go-text/render/pull/8) are safe.
