### PR TITLE
Harfbuzz tests

### DIFF
--- a/harfbuzz/harfbuzz_shape_input_test.go
+++ b/harfbuzz/harfbuzz_shape_input_test.go
@@ -173,7 +173,6 @@ func newTestInput(t testing.TB, options string) testInput {
 
 	fo := newFontOptions()
 
-	flags.StringVar(&fo.fontRef.File, "font-file", "", "Set font file-name")
 	fontRefIndex := flags.Int("face-index", 0, "Set face index (default: 0)")
 	flags.Func("font-size", "Font size", fo.parseFontSize)
 	flags.Func("font-ppem", "Set x,y pixels per EM (default: 0; disabled)", fo.parseFontPpem)

--- a/language/scripts.go
+++ b/language/scripts.go
@@ -12,8 +12,9 @@ import (
 type Script uint32
 
 // ParseScript simply converts a 4 bytes string into its binary encoding.
+// If [script] is longer, only its 4 first bytes are used.
 func ParseScript(script string) (Script, error) {
-	if len(script) != 4 {
+	if len(script) < 4 {
 		return 0, fmt.Errorf("invalid script string: %s", script)
 	}
 	return Script(binary.BigEndian.Uint32([]byte(script))), nil

--- a/language/scripts_test.go
+++ b/language/scripts_test.go
@@ -11,8 +11,9 @@ func TestParseScript(t *testing.T) {
 		want    Script
 		wantErr bool
 	}{
-		{"xxxxx", 0, true},
+		{"xxx", 0, true},
 		{"bamu", Bamum, false},
+		{"bamu_to_long", Bamum, false},
 		{"cyrl", Cyrillic, false},
 		{"samr", Samaritan, false},
 	}


### PR DESCRIPTION
This PR enables Harfbuzz tests for macos fonts to run (one test is using 'hebrew' instead of 'hebr' as script tag). See also https://github.com/go-text/typesetting-utils/pull/12 for more context.

Should have been included in #77, sorry for the oversight.