### PR TITLE
fontscan: expose footprint and means of registering existing faces

### DIFF
--- a/fontscan/footprint.go
+++ b/fontscan/footprint.go
@@ -36,6 +36,15 @@ type footprint struct {
 	IsMonospace bool
 }
 
+func newFootprintFromFont(f font.Font, md meta.Description) (out footprint) {
+	out.Runes = newRuneSetFromCmap(f.Cmap)
+	out.Family = meta.NormalizeFamily(md.Family)
+	out.Aspect = md.Aspect
+	out.IsMonospace = md.IsMonospace
+	out.Location.File = fmt.Sprintf("%v", md)
+	return out
+}
+
 func newFootprintFromLoader(ld *loader.Loader) (out footprint, err error) {
 	raw, err := ld.RawTable(loader.MustNewTag("cmap"))
 	if err != nil {


### PR DESCRIPTION
~This commit allows already-parsed fonts to be inserted into the fontmap from an application. In order to do this with valid rune coverage maps, I needed to export a way for applications to construct Footprints so that the footprint could be provided alongside the font (assuming that the loader is no longer available). I'm open to feedback on whether this is a good idea.~

~@benoitkugler I found that Gio needed a means of registering already-parsed fonts (loaded from embedded font files) into the fontmap, so this is my stab at making that work. Let me know what you think about the approach.~

I've rewritten this to avoid exposing implementation details. Now there's simply an `AddFace` method that inserts an existing face and its metadata.

Gio uses this to register already-in-memory fonts so that they can be considered during the font selection process. Additionally, frequently Gio applications do not specify a font family during shaping, relying on the fact that manually loaded faces will be selected in this case.

I've implemented selecting from manually-loaded faces as a fallback for when the substitution process fails. It seems like it doesn't violate the CSS spec in an important way (this decision is arbitrary, but it is also *useful*).

@benoitkugler Does this seem like a reasonable change? 