### PR TITLE
Reduce allocations in metadata

### DIFF
--- a/fontscan/footprint.go
+++ b/fontscan/footprint.go
@@ -79,9 +79,9 @@ func newFootprintFromLoader(ld *loader.Loader, isUserProvided bool, buffer scanB
 
 	out.Runes, buffer.cmapBuffer = newRuneSetFromCmap(cmap, buffer.cmapBuffer) // ... and build the corresponding rune set
 
-	desc := meta.NewFontDescriptor(ld)
-	out.Family = meta.NormalizeFamily(desc.Family())
-	out.Aspect = desc.Aspect()
+	family, aspect, raw := meta.Describe(ld, raw)
+	out.Family = meta.NormalizeFamily(family)
+	out.Aspect = aspect
 	out.isUserProvided = isUserProvided
 
 	buffer.tableBuffer = raw

--- a/opentype/api/font/font.go
+++ b/opentype/api/font/font.go
@@ -231,7 +231,8 @@ var bhedTag = loader.MustNewTag("bhed")
 // If a 'bhed' Apple table is present, it replaces the 'head' one.
 //
 // 'buffer' may be provided to reduce allocations; the return Head is guaranteed
-// not to retain any reference on 'buffer'
+// not to retain any reference on 'buffer'.
+// If 'buffer' is nil or has not enough capacity, a new slice is allocated (and returned).
 func LoadHeadTable(ld *loader.Loader, buffer []byte) (tables.Head, []byte, error) {
 	var err error
 	// check 'bhed' first

--- a/opentype/api/font/font.go
+++ b/opentype/api/font/font.go
@@ -97,7 +97,7 @@ func NewFont(ld *loader.Loader) (*Font, error) {
 		return nil, err
 	}
 
-	out.head, err = LoadHeadTable(ld)
+	out.head, _, err = LoadHeadTable(ld, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -229,22 +229,22 @@ var bhedTag = loader.MustNewTag("bhed")
 
 // LoadHeadTable loads the table corresponding to the 'head' tag.
 // If a 'bhed' Apple table is present, it replaces the 'head' one.
-func LoadHeadTable(ld *loader.Loader) (tables.Head, error) {
-	var (
-		s   []byte
-		err error
-	)
+//
+// 'buffer' may be provided to reduce allocations; the return Head is guaranteed
+// not to retain any reference on 'buffer'
+func LoadHeadTable(ld *loader.Loader, buffer []byte) (tables.Head, []byte, error) {
+	var err error
 	// check 'bhed' first
 	if ld.HasTable(bhedTag) {
-		s, err = ld.RawTable(bhedTag)
+		buffer, err = ld.RawTableTo(bhedTag, buffer)
 	} else {
-		s, err = ld.RawTable(loader.MustNewTag("head"))
+		buffer, err = ld.RawTableTo(loader.MustNewTag("head"), buffer)
 	}
 	if err != nil {
-		return tables.Head{}, errors.New("missing required head (or bhed) table")
+		return tables.Head{}, nil, errors.New("missing required head (or bhed) table")
 	}
-	out, _, err := tables.ParseHead(s)
-	return out, err
+	out, _, err := tables.ParseHead(buffer)
+	return out, buffer, err
 }
 
 // return nil if no table is valid (or present)

--- a/opentype/api/metadata/aspect.go
+++ b/opentype/api/metadata/aspect.go
@@ -148,7 +148,7 @@ type Aspect struct {
 
 // Aspect returns the [Aspect] of the font,
 // defaulting to regular style.
-func (fd *FontDescriptor) Aspect() Aspect {
+func (fd *fontDescriptor) Aspect() Aspect {
 	// use rawAspect and additionalStyle to infer the Aspect
 
 	out := fd.rawAspect() // load the aspect properties ...
@@ -203,7 +203,7 @@ func (as *Aspect) SetDefaults() {
 	}
 }
 
-func (fd *FontDescriptor) additionalStyle() string {
+func (fd *fontDescriptor) additionalStyle() string {
 	var style string
 	if fd.os2 != nil && fd.os2.FsSelection&256 != 0 {
 		style = fd.names.Name(namePreferredSubfamily)
@@ -223,7 +223,7 @@ func (fd *FontDescriptor) additionalStyle() string {
 	return style
 }
 
-func (fd *FontDescriptor) rawAspect() Aspect {
+func (fd *fontDescriptor) rawAspect() Aspect {
 	var (
 		style   Style
 		weight  Weight


### PR DESCRIPTION
Providing a buffer for metadata extractions reduces allocation during system fonts scan.

The API change is required to make sure we don't keep a reference on the shared buffer (whose content may have been overwritten before resolving the family and aspect).
