### PR TITLE
Fontscan fixes

### DIFF
--- a/fontscan/fontmap.go
+++ b/fontscan/fontmap.go
@@ -446,18 +446,6 @@ func (fm *FontMap) ResolveFace(r rune) font.Face {
 	fm.logger.Printf("No font matched for %v and rune %U (%c) -> returning arbitrary face", fm.query.Families, r, r)
 
 	// return an arbitrary face
-	for _, face := range fm.faceCache {
-		return face
-	}
-	for _, fp := range fm.database {
-		face, err := fm.loadFont(fp)
-		if err != nil { // very unlikely
-			continue
-		}
-		return face
-	}
-
-	// return an arbitrary face
 	if fm.firstFace == nil && len(fm.database) > 0 {
 		for _, fp := range fm.database {
 			face, err := fm.loadFont(fp)

--- a/fontscan/fontmap.go
+++ b/fontscan/fontmap.go
@@ -281,6 +281,9 @@ func (fm *FontMap) FontMetadata(ft font.Font) (family string, aspect meta.Aspect
 // SetQuery set the families and aspect required, influencing subsequent
 // `ResolveFace` calls.
 func (fm *FontMap) SetQuery(query Query) {
+	if len(query.Families) == 0 {
+		query.Families = []string{""}
+	}
 	fm.query = query
 
 	// since many runes will be looked for the same query,

--- a/fontscan/fontmap_test.go
+++ b/fontscan/fontmap_test.go
@@ -107,9 +107,6 @@ func TestResolveFallbackManual(t *testing.T) {
 	logger := log.New(os.Stdout, "", 0)
 	fm := NewFontMap(logger)
 
-	err := fm.UseSystemFonts(t.TempDir())
-	tu.AssertNoErr(t, err)
-
 	file1, err := os.Open("../font/testdata/Amiri-Regular.ttf")
 	tu.AssertNoErr(t, err)
 	defer file1.Close()
@@ -119,6 +116,7 @@ func TestResolveFallbackManual(t *testing.T) {
 	defer file2.Close()
 
 	err = fm.AddFont(file1, "user:Amiri", "")
+	err = fm.AddFont(file2, "user:Roboto", "")
 	tu.AssertNoErr(t, err)
 
 	fm.SetQuery(Query{}) // no families

--- a/fontscan/fontmap_test.go
+++ b/fontscan/fontmap_test.go
@@ -116,6 +116,7 @@ func TestResolveFallbackManual(t *testing.T) {
 	defer file2.Close()
 
 	err = fm.AddFont(file1, "user:Amiri", "")
+	tu.AssertNoErr(t, err)
 	err = fm.AddFont(file2, "user:Roboto", "")
 	tu.AssertNoErr(t, err)
 


### PR DESCRIPTION
This PR fixes a couple of small problems I've encountered with the fontscan API:

- If given an empty slice for queried font families, it used fail to find anything
- If we reached the "arbitrary face" return logic, we iterated over a map and returned a random face each iteration