### PR TITLE
[shaping] properly count clusters for vertical text

### DIFF
--- a/shaping/shaper.go
+++ b/shaping/shaper.go
@@ -168,10 +168,10 @@ func countClusters(glyphs []Glyph, textLen int, dir di.Direction) {
 			if nextCluster == -1 {
 				nextCluster = textLen
 			}
-			switch dir {
-			case di.DirectionLTR:
+			switch dir.Progression() {
+			case di.FromTopLeft:
 				runesInCluster = nextCluster - currentCluster
-			case di.DirectionRTL:
+			case di.TowardTopLeft:
 				runesInCluster = previousCluster - currentCluster
 			}
 			previousCluster = g


### PR DESCRIPTION
The `Glyph.RunesCount` property for vertical text was always 0, since `countClusters` was not handling vertical directions.

Besides, the `Progression` type makes the fix trivial, thanks for this idea !