### PR TITLE
opentype/api/font: use concrete error instead of fmt.Errorf

### DIFF
--- a/opentype/api/font/renderer.go
+++ b/opentype/api/font/renderer.go
@@ -271,10 +271,16 @@ func buildSegments(points []contourPoint) []api.Segment {
 	return out
 }
 
+type errGlyphOutOfRange int
+
+func (e errGlyphOutOfRange) Error() string {
+	return fmt.Sprintf("out of range glyph %d", e)
+}
+
 // apply variation when needed
 func (f *Face) glyphDataFromGlyf(glyph gID) (api.GlyphOutline, error) {
 	if int(glyph) >= len(f.glyf) {
-		return api.GlyphOutline{}, fmt.Errorf("out of range glyph %d", glyph)
+		return api.GlyphOutline{}, errGlyphOutOfRange(glyph)
 	}
 	var points []contourPoint
 	f.getPointsForGlyph(glyph, 0, &points)


### PR DESCRIPTION
This call to fmt.Errorf is a significant hotspot on Gio's shaping benchmarks. Using a concrete error type makes instantiating this error much cheaper and defers any acutal string formatting until when/if the error is printed.