### PR TITLE
fontscan: use interface for logger

### DIFF
--- a/fontscan/fontconfig.go
+++ b/fontscan/fontconfig.go
@@ -5,7 +5,6 @@ package fontscan
 import (
 	"encoding/xml"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -43,12 +42,12 @@ func fcVarsFromEnv() fcVars {
 }
 
 // resolveRoot returns the path of the root fontconfig file according to the fcVars.
-func (f fcVars) resolveRoot(logger *log.Logger) string {
+func (f fcVars) resolveRoot(logger Logger) string {
 	return f.resolvePath(logger, f.configFile)
 }
 
 // resolvePath applies fontconfig's heuristics for finding a path referenced within its config.
-func (f fcVars) resolvePath(logger *log.Logger, path string) string {
+func (f fcVars) resolvePath(logger Logger, path string) string {
 	hasSysroot := len(f.sysroot) > 0
 	if filepath.IsAbs(path) {
 		if hasSysroot && !strings.HasPrefix(path, f.sysroot) {
@@ -125,7 +124,7 @@ func (directive *fcDirective) UnmarshalXML(d *xml.Decoder, start xml.StartElemen
 // supplementary config files (or directories) to include.
 // The file parameter is expected to already be resolved by
 // resolvePath().
-func (fc fcVars) parseFcFile(logger *log.Logger, file, currentWorkingDir string) (fontDirs, includes []string, _ error) {
+func (fc fcVars) parseFcFile(logger Logger, file, currentWorkingDir string) (fontDirs, includes []string, _ error) {
 	f, err := os.Open(file)
 	if err != nil {
 		return nil, nil, fmt.Errorf("opening fontconfig config file: %s", err)
@@ -171,7 +170,7 @@ func (fc fcVars) parseFcFile(logger *log.Logger, file, currentWorkingDir string)
 // parseFcDir processes all the files in [dir] matching the [09]*.conf pattern
 // seen is updated with the processed fontconfig files. The dir parameter is
 // expected to already be resolved by resolvePath.
-func (fc fcVars) parseFcDir(logger *log.Logger, dir, currentWorkingDir string, seen map[string]bool) (fontDirs, includes []string, _ error) {
+func (fc fcVars) parseFcDir(logger Logger, dir, currentWorkingDir string, seen map[string]bool) (fontDirs, includes []string, _ error) {
 	entries, err := readDir(dir)
 	if err != nil {
 		return nil, nil, fmt.Errorf("reading fontconfig config directory: %s", err)
@@ -201,7 +200,7 @@ func (fc fcVars) parseFcDir(logger *log.Logger, dir, currentWorkingDir string, s
 
 // parseFcConfig recursively parses the fontconfig config file at [rootConfig]
 // and its includes, returning the font directories to scan
-func (fc fcVars) parseFcConfig(logger *log.Logger) ([]string, error) {
+func (fc fcVars) parseFcConfig(logger Logger) ([]string, error) {
 	root := fc.resolveRoot(logger)
 	seen := map[string]bool{root: true}
 

--- a/fontscan/scan.go
+++ b/fontscan/scan.go
@@ -4,7 +4,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"log"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -18,7 +17,7 @@ import (
 // DefaultFontDirectories return the OS-dependent usual directories for
 // fonts, or an error if no one exists.
 // These are the directories used by `FindFont` and `FontMap.UseSystemFonts` to locate fonts.
-func DefaultFontDirectories(logger *log.Logger) ([]string, error) {
+func DefaultFontDirectories(logger Logger) ([]string, error) {
 	var dirs []string
 	switch runtime.GOOS {
 	case "windows":
@@ -104,7 +103,7 @@ func DefaultFontDirectories(logger *log.Logger) ([]string, error) {
 		}
 
 		if !info.IsDir() {
-			logger.Println("font dir is not a directory", dir)
+			logger.Printf("font dir is not a directory: %q", dir)
 			continue
 		}
 
@@ -287,7 +286,7 @@ func (fa *footprintScanner) consume(path string, info os.FileInfo) error {
 // `currentIndex` may be passed to avoid scanning font files that are
 // already present in `currentIndex` and up to date, and directly duplicating
 // the footprint in `currentIndex`
-func scanFontFootprints(logger *log.Logger, currentIndex systemFontsIndex, dirs ...string) (systemFontsIndex, error) {
+func scanFontFootprints(logger Logger, currentIndex systemFontsIndex, dirs ...string) (systemFontsIndex, error) {
 	// keep track of visited dirs to avoid double inclusions,
 	// for instance with symbolic links
 	visited := make(map[string]bool)

--- a/fontscan/scandir_go1.16.go
+++ b/fontscan/scandir_go1.16.go
@@ -5,14 +5,13 @@ package fontscan
 
 import (
 	"io/fs"
-	"log"
 	"os"
 	"path/filepath"
 )
 
 // recursively walk through the given directory, scanning font files and calling dst.consume
 // for each valid file found.
-func (dst *footprintScanner) scanDirectory(logger *log.Logger, dir string, visited map[string]bool) error {
+func (dst *footprintScanner) scanDirectory(logger Logger, dir string, visited map[string]bool) error {
 	walkFn := func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			logger.Printf("error walking font directory %q: %v", path, err)

--- a/fontscan/scandir_old.go
+++ b/fontscan/scandir_old.go
@@ -4,14 +4,13 @@
 package fontscan
 
 import (
-	"log"
 	"os"
 	"path/filepath"
 )
 
 // recursively walk through the given directory, scanning font files and calling dst.consume
 // for each valid file found.
-func (dst *footprintScanner) scanDirectory(logger *log.Logger, dir string, visited map[string]bool) error {
+func (dst *footprintScanner) scanDirectory(logger Logger, dir string, visited map[string]bool) error {
 	walkFn := func(path string, d os.FileInfo, err error) error {
 		if err != nil {
 			logger.Printf("error walking font directory %q: %v", path, err)


### PR DESCRIPTION
This allows client applications to substitute different logging libraries than simply the stdlib by implementing an adapter that conforms to this interface.