### PR TITLE
shaping: fix empty string wrapping with width zero

### DIFF
--- a/shaping/wrapping.go
+++ b/shaping/wrapping.go
@@ -759,7 +759,7 @@ func (l *LineWrapper) WrapParagraph(config WrapConfig, maxWidth int, paragraph [
 		_, firstRun, hasFirst := runs.Next()
 		_, _, hasSecond := runs.Peek()
 		if hasFirst && !hasSecond {
-			if firstRun.Advance.Ceil() < maxWidth {
+			if firstRun.Advance.Ceil() <= maxWidth {
 				return l.scratch.singleRunParagraph(firstRun), 0
 			}
 		}
@@ -863,7 +863,7 @@ func (l *LineWrapper) WrapNextLine(maxWidth int) (finalLine Line, truncated int,
 	truncating := l.config.TruncateAfterLines == 1
 
 	// If we're not truncating, the iterator contains only one run, and that run fits, take the fast path.
-	if !(l.config.TextContinues && truncating) && firstRun.Runes.Offset == l.lineStartRune && firstRun.Advance.Ceil() < maxWidth {
+	if !(l.config.TextContinues && truncating) && firstRun.Runes.Offset == l.lineStartRune && firstRun.Advance.Ceil() <= maxWidth {
 		// Save current iterator state so we can peek ahead.
 		l.glyphRuns.Save()
 		// Advance beyond firstRun, which we already know from the Peek() above.

--- a/shaping/wrapping_test.go
+++ b/shaping/wrapping_test.go
@@ -949,6 +949,10 @@ func compareLines(t *testing.T, lineNumber int, expected, actual Line) {
 }
 
 func TestLineWrap(t *testing.T) {
+	emptyString := []Output{{
+		Size:       fixed.I(100),
+		LineBounds: Bounds{Ascent: fixed.I(-100), Descent: fixed.I(50)},
+	}}
 	type testcase struct {
 		name      string
 		shaped    []Output
@@ -957,6 +961,24 @@ func TestLineWrap(t *testing.T) {
 		expected  []Line
 	}
 	for _, tc := range []testcase{
+		{
+			// Wrapping the empty string should produce a run with no glyphs/runes but
+			// with valid line bounds.
+			name:      "empty string",
+			shaped:    emptyString,
+			paragraph: []rune{},
+			maxWidth:  1000,
+			expected:  []Line{emptyString},
+		},
+		{
+			// Wrapping the empty string should produce a run with no glyphs/runes but
+			// with valid line bounds (even if the available width is zero).
+			name:      "empty string zero width",
+			shaped:    emptyString,
+			paragraph: []rune{},
+			maxWidth:  0,
+			expected:  []Line{emptyString},
+		},
 		{
 			// This test case verifies that no line breaks occur if they are not
 			// necessary, and that the proper Offsets are reported in the output.


### PR DESCRIPTION
This commit ensures that we properly handle wrapping the empty string even when we have zero width to work with. It's common for application code to shape+wrap an empty string to get line metrics, and sometimes they may do that with zero width because the empty string needs no width. However, a faulty comparison in our logic for handling the empty string would fail because 0 is not less than 0. I've added tests triggering the problem and fixed the comparison logic.