### PR TITLE
Better space handling ?

### DIFF
--- a/shaping/output.go
+++ b/shaping/output.go
@@ -128,6 +128,29 @@ func (o *Output) RecomputeAdvance() {
 	o.Advance = advance
 }
 
+// advanceSpaceAware adjust the value in [Advance]
+// if a white space character end the run.
+// TODO: should be take into account multiple spaces ?
+func (o *Output) advanceSpaceAware() fixed.Int26_6 {
+	L := len(o.Glyphs)
+	if L == 0 {
+		return o.Advance
+	}
+
+	// adjust the last to account for spaces
+	if o.Direction.IsVertical() {
+		if g := o.Glyphs[L-1]; g.Height == 0 {
+			return o.Advance - g.YAdvance
+		}
+	} else { // horizontal
+		if g := o.Glyphs[L-1]; g.Width == 0 {
+			return o.Advance - g.XAdvance
+		}
+	}
+
+	return o.Advance
+}
+
 // RecalculateAll updates the all other fields of the Output
 // to match the current contents of the Glyphs field.
 // This method will fail with UnimplementedDirectionError if the Output

--- a/shaping/output.go
+++ b/shaping/output.go
@@ -129,8 +129,8 @@ func (o *Output) RecomputeAdvance() {
 }
 
 // advanceSpaceAware adjust the value in [Advance]
-// if a white space character end the run.
-// TODO: should be take into account multiple spaces ?
+// if a white space character ends the run.
+// TODO: should we take into account multiple spaces ?
 func (o *Output) advanceSpaceAware() fixed.Int26_6 {
 	L := len(o.Glyphs)
 	if L == 0 {

--- a/shaping/wrapping_test.go
+++ b/shaping/wrapping_test.go
@@ -2760,7 +2760,7 @@ func TestLineWrapperBreakSpecific(t *testing.T) {
 		},
 		{
 			paragraph: []rune("hello, world"),
-			// maxWidth of 56 with this truncator reuslts in ~40px of usable space for the text if the
+			// maxWidth of 56 with this truncator results in ~40px of usable space for the text if the
 			// truncator is present. The text "hello, " needs a little more space than this even if the
 			// space is shortened to width zero.
 			maxWidth:  56,

--- a/shaping/wrapping_test.go
+++ b/shaping/wrapping_test.go
@@ -2760,54 +2760,62 @@ func TestLineWrapperBreakSpecific(t *testing.T) {
 		},
 		{
 			paragraph: []rune("hello, world"),
-			maxWidth:  60,
+			// maxWidth of 56 with this truncator reuslts in ~40px of usable space for the text if the
+			// truncator is present. The text "hello, " needs a little more space than this even if the
+			// space is shortened to width zero.
+			maxWidth:  56,
 			truncator: []rune("…"),
 			expectations: []expectation{
 				{
+					// We are forced to wrap within a word here.
 					name:           "WhenNecessary-Truncate",
 					config:         WrapConfig{BreakPolicy: WhenNecessary, TruncateAfterLines: 1},
-					runeCounts:     []int{7},
-					truncatedCount: 5,
+					runeCounts:     []int{5},
+					truncatedCount: 7,
 				},
 				{
+					// We are forced to wrap within a word here.
 					name:           "Always-Truncate",
 					config:         WrapConfig{BreakPolicy: Always, TruncateAfterLines: 1},
-					runeCounts:     []int{7},
-					truncatedCount: 5,
+					runeCounts:     []int{5},
+					truncatedCount: 7,
 				},
 				{
+					// Since we can't wrap within words in this configuration, we truncate all runes.
 					name:           "Never-Truncate",
 					config:         WrapConfig{BreakPolicy: Never, TruncateAfterLines: 1},
-					runeCounts:     []int{7},
-					truncatedCount: 5,
+					runeCounts:     []int{},
+					truncatedCount: 12,
 				},
 			},
 		},
 		{
+			// The first word "hello, " doesn't quite fit in 40 pixels. These tests exercise this boundary
+			// condition with various break policies and truncation policies.
 			paragraph: []rune("hello, world"),
-			maxWidth:  44,
+			maxWidth:  40,
 			expectations: []expectation{
 				{
 					name:       "WhenNecessary",
 					config:     WrapConfig{BreakPolicy: WhenNecessary},
-					runeCounts: []int{7, 5},
+					runeCounts: []int{5, 2, 5},
 				},
 				{
 					name:           "WhenNecessary-Truncate",
 					config:         WrapConfig{BreakPolicy: WhenNecessary, TruncateAfterLines: 1},
-					runeCounts:     []int{7},
-					truncatedCount: 5,
+					runeCounts:     []int{5},
+					truncatedCount: 7,
 				},
 				{
 					name:       "Always",
 					config:     WrapConfig{BreakPolicy: Always},
-					runeCounts: []int{7, 5},
+					runeCounts: []int{5, 6, 1},
 				},
 				{
 					name:           "Always-Truncate",
 					config:         WrapConfig{BreakPolicy: Always, TruncateAfterLines: 1},
-					runeCounts:     []int{7},
-					truncatedCount: 5,
+					runeCounts:     []int{5},
+					truncatedCount: 7,
 				},
 				{
 					name:       "Never",
@@ -2817,8 +2825,8 @@ func TestLineWrapperBreakSpecific(t *testing.T) {
 				{
 					name:           "Never-Truncate",
 					config:         WrapConfig{BreakPolicy: Never, TruncateAfterLines: 1},
-					runeCounts:     []int{7},
-					truncatedCount: 5,
+					runeCounts:     []int{},
+					truncatedCount: 12,
 				},
 			},
 		},

--- a/shaping/wrapping_test.go
+++ b/shaping/wrapping_test.go
@@ -2772,14 +2772,14 @@ func TestLineWrapperBreakSpecific(t *testing.T) {
 				{
 					name:           "Always-Truncate",
 					config:         WrapConfig{BreakPolicy: Always, TruncateAfterLines: 1},
-					runeCounts:     []int{6},
-					truncatedCount: 6,
+					runeCounts:     []int{7},
+					truncatedCount: 5,
 				},
 				{
 					name:           "Never-Truncate",
 					config:         WrapConfig{BreakPolicy: Never, TruncateAfterLines: 1},
-					runeCounts:     []int{},
-					truncatedCount: 12,
+					runeCounts:     []int{7},
+					truncatedCount: 5,
 				},
 			},
 		},
@@ -2790,24 +2790,24 @@ func TestLineWrapperBreakSpecific(t *testing.T) {
 				{
 					name:       "WhenNecessary",
 					config:     WrapConfig{BreakPolicy: WhenNecessary},
-					runeCounts: []int{6, 6},
+					runeCounts: []int{7, 5},
 				},
 				{
 					name:           "WhenNecessary-Truncate",
 					config:         WrapConfig{BreakPolicy: WhenNecessary, TruncateAfterLines: 1},
-					runeCounts:     []int{6},
-					truncatedCount: 6,
+					runeCounts:     []int{7},
+					truncatedCount: 5,
 				},
 				{
 					name:       "Always",
 					config:     WrapConfig{BreakPolicy: Always},
-					runeCounts: []int{6, 6},
+					runeCounts: []int{7, 5},
 				},
 				{
 					name:           "Always-Truncate",
 					config:         WrapConfig{BreakPolicy: Always, TruncateAfterLines: 1},
-					runeCounts:     []int{6},
-					truncatedCount: 6,
+					runeCounts:     []int{7},
+					truncatedCount: 5,
 				},
 				{
 					name:       "Never",
@@ -2817,8 +2817,8 @@ func TestLineWrapperBreakSpecific(t *testing.T) {
 				{
 					name:           "Never-Truncate",
 					config:         WrapConfig{BreakPolicy: Never, TruncateAfterLines: 1},
-					runeCounts:     []int{},
-					truncatedCount: 12,
+					runeCounts:     []int{7},
+					truncatedCount: 5,
 				},
 			},
 		},
@@ -2886,12 +2886,12 @@ func TestLineWrapperBreakSpecific(t *testing.T) {
 				{
 					name:       "WhenNecessary",
 					config:     WrapConfig{BreakPolicy: WhenNecessary},
-					runeCounts: []int{1, 1, 2, 1, 1, 1, 1, 1, 1, 1, 1},
+					runeCounts: []int{1, 1, 2, 1, 2, 1, 1, 1, 1, 1},
 				},
 				{
 					name:       "Always",
 					config:     WrapConfig{BreakPolicy: Always},
-					runeCounts: []int{1, 1, 2, 1, 1, 1, 1, 1, 1, 1, 1},
+					runeCounts: []int{1, 1, 2, 1, 2, 1, 1, 1, 1, 1},
 				},
 				{
 					name:       "Never",
@@ -3209,7 +3209,7 @@ var regressionRuns = []Output{
 	},
 }
 
-func TestSpace(t *testing.T) {
+func TestTrailingSpace(t *testing.T) {
 	// assume single run, 1 to 1 rune <-> glyph mapping
 	shapedText := func(text []rune, line Line) string {
 		tu.Assert(t, len(line) == 1)


### PR DESCRIPTION
Following the discussion on #90 , this is a try at better handling trailing spaces.

This is not complete (tests are not event passing), but I would be interested in early feedback.

One of the difficulty is about handling truncation properly :
I think the behavior should be, for a width of 5, to truncate
`quick_fox`
to 
`quick_...` (but with a zero advance space)
and not to 
`quick...`