### PR TITLE
[fontscan] Better family substitutions

### DIFF
--- a/fontscan/fontmap_test.go
+++ b/fontscan/fontmap_test.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -259,4 +260,23 @@ func TestFontMap_AddFont_FaceLocation(t *testing.T) {
 	fm.SetQuery(Query{Families: []string{"MyRoboto"}})
 	face := fm.ResolveFace(0x20)
 	tu.Assert(t, fm.FontLocation(face.Font).File == "Roboto2")
+}
+
+func TestQueryHelveticaLinux(t *testing.T) {
+	// This is a regression test which asserts that
+	// our behavior is similar than fontconfig, on a linux system
+	if runtime.GOOS != "linux" {
+		t.Skip()
+	}
+
+	fm := NewFontMap(nil)
+	err := fm.UseSystemFonts(t.TempDir())
+	tu.AssertNoErr(t, err)
+
+	fm.SetQuery(Query{Families: []string{
+		"BlinkMacSystemFont", // 'unknown' family
+		"Helvetica",
+	}})
+	family, _ := fm.FontMetadata(fm.ResolveFace('x').Font)
+	tu.Assert(t, family == meta.NormalizeFamily("Nimbus Sans"))
 }

--- a/fontscan/fontmap_test.go
+++ b/fontscan/fontmap_test.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 	"time"
 
@@ -264,13 +263,17 @@ func TestFontMap_AddFont_FaceLocation(t *testing.T) {
 
 func TestQueryHelveticaLinux(t *testing.T) {
 	// This is a regression test which asserts that
-	// our behavior is similar than fontconfig, on a linux system
-	if runtime.GOOS != "linux" {
-		t.Skip()
-	}
+	// our behavior is similar than fontconfig
+
+	file1, err := os.Open("../font/testdata/Amiri-Regular.ttf")
+	tu.AssertNoErr(t, err)
+	defer file1.Close()
 
 	fm := NewFontMap(nil)
-	err := fm.UseSystemFonts(t.TempDir())
+	err = fm.AddFont(file1, "file1", "Nimbus Sans")
+	tu.AssertNoErr(t, err)
+
+	err = fm.AddFont(file1, "file2", "Bitstream Vera Sans")
 	tu.AssertNoErr(t, err)
 
 	fm.SetQuery(Query{Families: []string{
@@ -278,5 +281,5 @@ func TestQueryHelveticaLinux(t *testing.T) {
 		"Helvetica",
 	}})
 	family, _ := fm.FontMetadata(fm.ResolveFace('x').Font)
-	tu.Assert(t, family == meta.NormalizeFamily("Nimbus Sans"))
+	tu.Assert(t, family == meta.NormalizeFamily("Nimbus Sans")) // prefered Helvetica replacement
 }

--- a/fontscan/footprint.go
+++ b/fontscan/footprint.go
@@ -23,6 +23,8 @@ type footprint struct {
 
 	// Family is the general nature of the font, like
 	// "Arial"
+	// Note that, for performance reason, we store the
+	// normalized version of the family name.
 	Family string
 
 	// Runes is the set of runes supported by the font.

--- a/fontscan/match_test.go
+++ b/fontscan/match_test.go
@@ -103,13 +103,6 @@ func TestFontMap_selectByFamily(t *testing.T) {
 	}
 }
 
-func BenchmarkNewFamilyCrible(b *testing.B) {
-	c := make(familyCrible)
-	for i := 0; i < b.N; i++ {
-		c.fillWithSubstitutions("Arial")
-	}
-}
-
 func fontsetFromStretches(sts ...meta.Stretch) (out fontSet) {
 	for _, stretch := range sts {
 		out = append(out, footprint{Aspect: meta.Aspect{Stretch: stretch}})

--- a/fontscan/substitutions.go
+++ b/fontscan/substitutions.go
@@ -27,16 +27,20 @@ func init() {
 	}
 }
 
-// familyList is a list of family to match, order
+// familyList is a list of normalized families to match, order
 // by user preference (first is best).
 // It also implements helpers to insert at the start,
 // the end and "around" an element
 type familyList []string
 
+// normalize the families
 func newFamilyList(families []string) familyList {
 	// we'll guess that we end up with about ~140 items
 	fl := make([]string, 0, 140)
 	fl = append(fl, families...)
+	for i, f := range fl {
+		fl[i] = meta.NormalizeFamily(f)
+	}
 	return fl
 }
 

--- a/fontscan/substitutions.go
+++ b/fontscan/substitutions.go
@@ -27,23 +27,22 @@ func init() {
 	}
 }
 
-// we want to easily insert at the start,
+// familyList is a list of family to match, order
+// by user preference (first is best).
+// It also implements helpers to insert at the start,
 // the end and "around" an element
-type familyList struct {
-	items []string
-}
+type familyList []string
 
-func newFamilyList(families []string) *familyList {
-	fl := &familyList{}
+func newFamilyList(families []string) familyList {
 	// we'll guess that we end up with about ~140 items
-	fl.items = make([]string, 0, 140)
-	fl.items = append(fl.items, families...)
+	fl := make([]string, 0, 140)
+	fl = append(fl, families...)
 	return fl
 }
 
 // returns the node equal to `family` or -1, if not found
-func (fl *familyList) elementEquals(family string) int {
-	for i, v := range fl.items {
+func (fl familyList) elementEquals(family string) int {
+	for i, v := range fl {
 		if v == family {
 			return i
 		}
@@ -52,8 +51,8 @@ func (fl *familyList) elementEquals(family string) int {
 }
 
 // returns the first node containing `family` or -1, if not found
-func (fl *familyList) elementContains(family string) int {
-	for i, v := range fl.items {
+func (fl familyList) elementContains(family string) int {
+	for i, v := range fl {
 		if strings.Contains(v, family) {
 			return i
 		}
@@ -62,8 +61,8 @@ func (fl *familyList) elementContains(family string) int {
 }
 
 // return the crible corresponding to the order
-func (fl *familyList) compileTo(dst familyCrible) {
-	for i, family := range fl.items {
+func (fl familyList) compileTo(dst familyCrible) {
+	for i, family := range fl {
 		if _, has := dst[family]; !has { // for duplicated entries, keep the first (best) score
 			dst[family] = i
 		}
@@ -71,25 +70,25 @@ func (fl *familyList) compileTo(dst familyCrible) {
 }
 
 func (fl *familyList) insertStart(families []string) {
-	fl.items = insertAt(fl.items, 0, families)
+	*fl = insertAt(*fl, 0, families)
 }
 
 func (fl *familyList) insertEnd(families []string) {
-	fl.items = insertAt(fl.items, len(fl.items), families)
+	*fl = insertAt(*fl, len(*fl), families)
 }
 
 // insertAfter inserts families right after element
 func (fl *familyList) insertAfter(element int, families []string) {
-	fl.items = insertAt(fl.items, element+1, families)
+	*fl = insertAt(*fl, element+1, families)
 }
 
 // insertBefore inserts families right before element
 func (fl *familyList) insertBefore(element int, families []string) {
-	fl.items = insertAt(fl.items, element, families)
+	*fl = insertAt(*fl, element, families)
 }
 
 func (fl *familyList) replace(element int, families []string) {
-	fl.items = replaceAt(fl.items, element, element+1, families)
+	*fl = replaceAt(*fl, element, element+1, families)
 }
 
 // ----- substitutions ------
@@ -109,9 +108,9 @@ const (
 type substitutionTest interface {
 	// returns >= 0 if the substitution should be applied
 	// for opAppendLast and opPrependFirst an arbitrary value could be returned
-	test(list *familyList) int
+	test(list familyList) int
 
-	// return a copy where families have been normalize
+	// return a copy where families have been normalized
 	// to their no blank no case version
 	normalize() substitutionTest
 }
@@ -119,7 +118,7 @@ type substitutionTest interface {
 // a family in the list must equal 'mf'
 type familyEquals string
 
-func (mf familyEquals) test(list *familyList) int {
+func (mf familyEquals) test(list familyList) int {
 	return list.elementEquals(string(mf))
 }
 
@@ -130,7 +129,7 @@ func (mf familyEquals) normalize() substitutionTest {
 // a family in the list must contain 'mf'
 type familyContains string
 
-func (mf familyContains) test(list *familyList) int {
+func (mf familyContains) test(list familyList) int {
 	return list.elementContains(string(mf))
 }
 
@@ -141,8 +140,8 @@ func (mf familyContains) normalize() substitutionTest {
 // the family list has no "serif", "sans-serif" or "monospace" generic fallback
 type noGenericFamily struct{}
 
-func (noGenericFamily) test(list *familyList) int {
-	for _, v := range list.items {
+func (noGenericFamily) test(list familyList) int {
+	for _, v := range list {
 		switch v {
 		case "serif", "sans-serif", "monospace":
 			return -1
@@ -163,7 +162,7 @@ type langAndFamilyEqual struct {
 }
 
 // TODO: for now, these tests language base tests are ignored
-func (langAndFamilyEqual) test(list *familyList) int {
+func (langAndFamilyEqual) test(list familyList) int {
 	return -1
 }
 
@@ -180,7 +179,7 @@ type langContainsAndFamilyEquals struct {
 }
 
 // TODO: for now, these tests language base tests are ignored
-func (langContainsAndFamilyEquals) test(list *familyList) int {
+func (langContainsAndFamilyEquals) test(list familyList) int {
 	return -1
 }
 
@@ -197,7 +196,7 @@ type langEqualsAndNoFamily struct {
 }
 
 // TODO: for now, these tests language base tests are ignored
-func (langEqualsAndNoFamily) test(list *familyList) int {
+func (langEqualsAndNoFamily) test(list familyList) int {
 	return -1
 }
 
@@ -213,7 +212,7 @@ type substitution struct {
 }
 
 func (fl *familyList) execute(subs substitution) {
-	element := subs.test.test(fl)
+	element := subs.test.test(*fl)
 	if element < 0 {
 		return
 	}

--- a/fontscan/substitutions_test.go
+++ b/fontscan/substitutions_test.go
@@ -232,3 +232,10 @@ func TestReplaceAt(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkNewFamilyCrible(b *testing.B) {
+	c := make(familyCrible)
+	for i := 0; i < b.N; i++ {
+		c.fillWithSubstitutions("Arial")
+	}
+}

--- a/fontscan/substitutions_test.go
+++ b/fontscan/substitutions_test.go
@@ -3,6 +3,9 @@ package fontscan
 import (
 	"reflect"
 	"testing"
+
+	meta "github.com/go-text/typesetting/opentype/api/metadata"
+	tu "github.com/go-text/typesetting/opentype/testutils"
 )
 
 func Test_familyList_insertStart(t *testing.T) {
@@ -238,4 +241,15 @@ func BenchmarkNewFamilyCrible(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		c.fillWithSubstitutions("Arial")
 	}
+}
+
+func TestSubstituteHelveticaOrder(t *testing.T) {
+	c := make(familyCrible)
+	c.fillWithSubstitutionsList([]string{meta.NormalizeFamily("BlinkMacSystemFont"), meta.NormalizeFamily("Helvetica")})
+	// BlinkMacSystemFont is not known by the library, so it is expanded with generic sans-serif,
+	// but with lower priority then Helvetica
+	l := c.families()
+	tu.Assert(t, l[0] == meta.NormalizeFamily("BlinkMacSystemFont"))
+	tu.Assert(t, l[1] == meta.NormalizeFamily("Helvetica"))
+	tu.Assert(t, l[2] == meta.NormalizeFamily("Nimbus Sans")) // from Helvetica
 }


### PR DESCRIPTION
This PR alters the way we perform family substitutions when looking for a fallback font, by applying them to the whole family list of the user query, so that substitution priorities are better respected.

Let me illustrate the change on the following example, where an user queries `{CustomWeirdFont, Helvetica}`, on a system with neither `CustomWeirdFont` nor `Helvetica`, and calls `ResolveFace('a')`

### Before the change

No exact match occurs (step 1), so we apply substitutions (step 2). `CustomWeirdFont` is unknown from the library rules, so it is expanded by default to `sans-serif` for which the system has (many) fonts (with support for the rune 'a'). So `ResolveFace` returns the 'preferred' `sans-serif` face. It has not take into account the `Helvetica` substitutions.

### After the change 

We still look for an exact match, in the user query order. Like before, no one occurs. We now apply substitutions on the whole  `{CustomWeirdFont, Helvetica}` list. Since the library has rules for `Helvetica`, the expanded families will look like `{CustomWeirdFont, Helvetica, NimbusSans, ..., other sans-serif families}`, with the main difference being that `NimbusSans`, which is the preferred substitution for `Helvetica`, has now higher priority than the default sans-serif substitutions coming from `CustomWeirdFont`.


This behavior is closer to what fontconfig does on Linux systems, and seems overall a better way of looking for fallbacks.