### PR TITLE
[harfbuzz] reuse otApplyContext instead of allocating a new one

### DIFF
--- a/harfbuzz/ot_arabic.go
+++ b/harfbuzz/ot_arabic.go
@@ -889,7 +889,8 @@ func newArabicFallbackPlan(plan *otShapePlan, font *Font) *arabicFallbackPlan {
 }
 
 func (fbPlan *arabicFallbackPlan) shape(font *Font, buffer *Buffer) {
-	c := newOtApplyContext(0, font, buffer)
+	var c otApplyContext
+	c.reset(0, font, buffer)
 	for i := 0; i < fbPlan.numLookups; i++ {
 		if fbPlan.accelArray[i].lookup != nil {
 			c.setLookupMask(fbPlan.maskArray[i])

--- a/harfbuzz/ot_kern.go
+++ b/harfbuzz/ot_kern.go
@@ -13,7 +13,10 @@ func simpleKern(kernTable fontP.Kernx) fontP.SimpleKerns {
 
 func kern(driver fontP.SimpleKerns, crossStream bool, font *Font, buffer *Buffer, kernMask GlyphMask, scale bool) {
 	buffer.unsafeToConcat(0, maxInt)
-	c := newOtApplyContext(1, font, buffer)
+
+	var c otApplyContext
+
+	c.reset(1, font, buffer)
 	c.setLookupMask(kernMask)
 	c.setLookupProps(uint32(otIgnoreMarks))
 	skippyIter := &c.iterInput

--- a/harfbuzz/ot_layout_gsubgpos.go
+++ b/harfbuzz/ot_layout_gsubgpos.go
@@ -351,26 +351,38 @@ type otApplyContext struct {
 	lastBaseUntil int // GPOS uses
 }
 
-func newOtApplyContext(tableIndex uint8, font *Font, buffer *Buffer) otApplyContext {
-	var out otApplyContext
-	out.font = font
-	out.buffer = buffer
-	out.gdef = font.face.GDEF
-	out.varStore = out.gdef.ItemVarStore
-	out.digest = buffer.digest()
-	out.direction = buffer.Props.Direction
-	out.lookupMask = 1
-	out.tableIndex = tableIndex
-	out.lookupIndex = math.MaxUint16
-	out.nestingLevelLeft = maxNestingLevel
-	out.hasGlyphClasses = out.gdef.GlyphClassDef != nil
-	out.autoZWNJ = true
-	out.autoZWJ = true
-	out.randomState = 1
-	out.newSyllables = 0xFF
-	out.lastBase = -1
-	out.initIters()
-	return out
+func (c *otApplyContext) reset(tableIndex uint8, font *Font, buffer *Buffer) {
+	c.font = font
+	c.buffer = buffer
+
+	c.recurseFunc = nil
+	c.gdef = font.face.GDEF
+	c.varStore = c.gdef.ItemVarStore
+	c.indices = c.indices[:0]
+
+	c.digest = buffer.digest()
+
+	c.nestingLevelLeft = maxNestingLevel
+	c.tableIndex = tableIndex
+	c.lookupMask = 1
+	c.lookupProps = 0
+	c.randomState = 1
+	c.lookupIndex = 0
+	c.direction = buffer.Props.Direction
+
+	c.hasGlyphClasses = c.gdef.GlyphClassDef != nil
+	c.autoZWNJ = true
+	c.autoZWJ = true
+	c.perSyllable = false
+	c.newSyllables = 0xFF
+	c.random = false
+
+	c.lastBase = -1
+	c.lastBaseUntil = 0
+
+	// iterContext
+	// iterInput
+	c.initIters()
 }
 
 func (c *otApplyContext) initIters() {

--- a/harfbuzz/ot_map.go
+++ b/harfbuzz/ot_map.go
@@ -383,9 +383,9 @@ type otMap struct {
 	chosenScript [2]tables.Tag
 	globalMask   GlyphMask
 	foundScript  [2]bool
-}
 
-//   friend struct hb_ot_map_builder_t;
+	applyContext otApplyContext // buffer
+}
 
 func (m *otMap) needsFallback(featureTag tables.Tag) bool {
 	if ma := bsearchFeature(m.features, featureTag); ma != nil {
@@ -485,7 +485,9 @@ func (m *otMap) position(plan *otShapePlan, font *Font, buffer *Buffer) {
 func (m *otMap) apply(proxy otProxy, plan *otShapePlan, font *Font, buffer *Buffer) {
 	tableIndex := proxy.tableIndex
 	i := 0
-	c := newOtApplyContext(tableIndex, font, buffer)
+	c := &m.applyContext
+
+	c.reset(tableIndex, font, buffer)
 	c.recurseFunc = proxy.recurseFunc
 
 	for stageI, stage := range m.stages[tableIndex] {


### PR DESCRIPTION
This makes `Buffer` more memory efficient when reusing the same font, since the `otMap` is stored on the buffer `planCache` .