### PR TITLE
[fontscan] Expose a way to query a system font by family

### DIFF
--- a/fontscan/fontmap.go
+++ b/fontscan/fontmap.go
@@ -314,6 +314,26 @@ func (fm *FontMap) FontMetadata(ft font.Font) (family string, aspect meta.Aspect
 	return item.Family, item.Aspect
 }
 
+// FindSystemFont looks for a system font with the given [family],
+// returning the first match, or false is no one is found.
+//
+// User added fonts are ignored, and the [FontMap] must have been
+// initialized with [UseSystemFonts] or this method will always return false.
+//
+// Family names are compared through [meta.Normalize].
+func (fm *FontMap) FindSystemFont(family string) (Location, bool) {
+	family = meta.NormalizeFamily(family)
+	for _, footprint := range fm.database {
+		if footprint.isUserProvided {
+			continue
+		}
+		if footprint.Family == family {
+			return footprint.Location, true
+		}
+	}
+	return Location{}, false
+}
+
 // SetQuery set the families and aspect required, influencing subsequent
 // `ResolveFace` calls.
 func (fm *FontMap) SetQuery(query Query) {

--- a/fontscan/fontmap_test.go
+++ b/fontscan/fontmap_test.go
@@ -260,3 +260,33 @@ func TestFontMap_AddFont_FaceLocation(t *testing.T) {
 	face := fm.ResolveFace(0x20)
 	tu.Assert(t, fm.FontLocation(face.Font).File == "Roboto2")
 }
+
+func TestFindSytemFont(t *testing.T) {
+	fm := NewFontMap(log.New(io.Discard, "", 0))
+	_, ok := fm.FindSystemFont("Nimbus")
+	tu.Assert(t, !ok) // no match on an empty fontmap
+
+	// simulate system fonts
+	fm.appendFootprints(footprint{
+		Family:   meta.NormalizeFamily("Nimbus"),
+		Location: Location{File: "nimbus.ttf"},
+	},
+		footprint{
+			Family:         meta.NormalizeFamily("Noto Sans"),
+			Location:       Location{File: "noto.ttf"},
+			isUserProvided: true,
+		},
+	)
+
+	nimbus, ok := fm.FindSystemFont("Nimbus")
+	tu.Assert(t, ok && nimbus.File == "nimbus.ttf")
+
+	_, ok = fm.FindSystemFont("nimbus ")
+	tu.Assert(t, ok)
+
+	_, ok = fm.FindSystemFont("Arial")
+	tu.Assert(t, !ok)
+
+	_, ok = fm.FindSystemFont("Noto Sans")
+	tu.Assert(t, !ok) // user provided font are ignored
+}


### PR DESCRIPTION
CSS [@font-face rule](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face) allows a document author to query a system (or local) font by _family name_. Although similar to the functionnality `SetQuery` and `ResolveFace` are providing, this is a different task (no rune involved, no aspect involved, only the system fonts are used).  Also, no fallback is desirable.

This PR then provides a `FindSystemFont(family string)` (its implementation is rather simple with our internal index).