### PR TITLE
[opentype/metadata] Fix aspect resolution

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.17
 
 require (
 	github.com/go-text/typesetting-utils v0.0.0-20231121125213-61dadda55b86
-	golang.org/x/image v0.14.0
+	golang.org/x/image v0.3.0
 )

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/go-text/typesetting
 go 1.17
 
 require (
-	github.com/go-text/typesetting-utils v0.0.0-20230616150549-2a7df14b6a22
-	golang.org/x/image v0.3.0
+	github.com/go-text/typesetting-utils v0.0.0-20231121125213-61dadda55b86
+	golang.org/x/image v0.14.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,3 @@
-github.com/go-text/typesetting-utils v0.0.0-20230616150549-2a7df14b6a22 h1:LBQTFxP2MfsyEDqSKmUBZaDuDHN1vpqDyOZjcqS7MYI=
-github.com/go-text/typesetting-utils v0.0.0-20230616150549-2a7df14b6a22/go.mod h1:DDxDdQEnB70R8owOx3LVpEFvpMK9eeH1o2r0yZhFI9o=
-github.com/go-text/typesetting-utils v0.0.0-20231113182824-2a0ec5518c32 h1:0jpkYDAFku6a/XoqlmvCr4P6I27TSmnwAoPx6b22/2Q=
-github.com/go-text/typesetting-utils v0.0.0-20231113182824-2a0ec5518c32/go.mod h1:DDxDdQEnB70R8owOx3LVpEFvpMK9eeH1o2r0yZhFI9o=
 github.com/go-text/typesetting-utils v0.0.0-20231121125213-61dadda55b86 h1:PZEJHpJCgm6PTMCYQOhXWpW7RbJ/k+AAeyHtDQK9Txc=
 github.com/go-text/typesetting-utils v0.0.0-20231121125213-61dadda55b86/go.mod h1:DDxDdQEnB70R8owOx3LVpEFvpMK9eeH1o2r0yZhFI9o=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
@@ -9,8 +5,6 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/image v0.3.0 h1:HTDXbdK9bjfSWkPzDJIw89W8CAtfFGduujWs33NLLsg=
 golang.org/x/image v0.3.0/go.mod h1:fXd9211C/0VTlYuAcOhW8dY/RtEJqODXOWBDpmYBf+A=
-golang.org/x/image v0.14.0 h1:tNgSxAFe3jC4uYqvZdTr84SZoM1KfwdC9SKIFrLjFn4=
-golang.org/x/image v0.14.0/go.mod h1:HUYqC05R2ZcZ3ejNQsIHQDQiwWM4JBqmm6MKANTp4LE=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,16 @@
 github.com/go-text/typesetting-utils v0.0.0-20230616150549-2a7df14b6a22 h1:LBQTFxP2MfsyEDqSKmUBZaDuDHN1vpqDyOZjcqS7MYI=
 github.com/go-text/typesetting-utils v0.0.0-20230616150549-2a7df14b6a22/go.mod h1:DDxDdQEnB70R8owOx3LVpEFvpMK9eeH1o2r0yZhFI9o=
+github.com/go-text/typesetting-utils v0.0.0-20231113182824-2a0ec5518c32 h1:0jpkYDAFku6a/XoqlmvCr4P6I27TSmnwAoPx6b22/2Q=
+github.com/go-text/typesetting-utils v0.0.0-20231113182824-2a0ec5518c32/go.mod h1:DDxDdQEnB70R8owOx3LVpEFvpMK9eeH1o2r0yZhFI9o=
+github.com/go-text/typesetting-utils v0.0.0-20231121125213-61dadda55b86 h1:PZEJHpJCgm6PTMCYQOhXWpW7RbJ/k+AAeyHtDQK9Txc=
+github.com/go-text/typesetting-utils v0.0.0-20231121125213-61dadda55b86/go.mod h1:DDxDdQEnB70R8owOx3LVpEFvpMK9eeH1o2r0yZhFI9o=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/image v0.3.0 h1:HTDXbdK9bjfSWkPzDJIw89W8CAtfFGduujWs33NLLsg=
 golang.org/x/image v0.3.0/go.mod h1:fXd9211C/0VTlYuAcOhW8dY/RtEJqODXOWBDpmYBf+A=
+golang.org/x/image v0.14.0 h1:tNgSxAFe3jC4uYqvZdTr84SZoM1KfwdC9SKIFrLjFn4=
+golang.org/x/image v0.14.0/go.mod h1:HUYqC05R2ZcZ3ejNQsIHQDQiwWM4JBqmm6MKANTp4LE=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=

--- a/opentype/api/metadata/descriptor_test.go
+++ b/opentype/api/metadata/descriptor_test.go
@@ -26,6 +26,11 @@ func TestMetadata(t *testing.T) {
 			Aspect{StyleNormal, WeightNormal, StretchNormal},
 			"Noto Sans Arabic",
 		},
+		{
+			"common/DejaVuSans.ttf",
+			Aspect{StyleNormal, WeightNormal, StretchNormal},
+			"DejaVu Sans",
+		},
 	}
 
 	for _, test := range tests {
@@ -87,4 +92,23 @@ func TestAspect_inferFromStyle(t *testing.T) {
 		as.inferFromStyle(tt.args)
 		tu.AssertC(t, as == tt.want, tt.args)
 	}
+}
+
+func TestAspectFromOS2(t *testing.T) {
+	// This font has two different weight values :
+	// 400, in the OS/2 table and 380, in the style description
+	f, err := td.Files.ReadFile("common/DejaVuSans.ttf")
+	tu.AssertNoErr(t, err)
+
+	ld, err := loader.NewLoader(bytes.NewReader(f))
+	tu.AssertNoErr(t, err)
+
+	fd, _ := newFontDescriptor(ld, nil)
+
+	raw := fd.rawAspect()
+	tu.Assert(t, raw.Weight == WeightNormal)
+
+	var inferred Aspect
+	inferred.inferFromStyle(fd.additionalStyle())
+	tu.Assert(t, inferred.Weight == 380)
 }


### PR DESCRIPTION
Previous to this change, we were not using the 'OS/2' table when computing the `Aspect` of a font. 

It is actually an outstanding issue, but it went undetected since the fallback `inferFromStyle` was doing a pretty good job. 

However, there is (at least) one font (DejaVu Sans) which has different values for its weight (that is, the OS/2 and style string values do not match). In this case, it is better to give priority to the 'OS/2' table (at least, that is what fontconfig does).

Also, I've added the font file in the merged https://github.com/go-text/typesetting-utils/pull/14 PR.