### PR TITLE
[opentype/gpos] use plain struct instead of pointer

### DIFF
--- a/harfbuzz/ot_layout_gpos.go
+++ b/harfbuzz/ot_layout_gpos.go
@@ -285,8 +285,8 @@ func (c *otApplyContext) applyGPOSPair1(inner tables.PairPosData1, index int) bo
 	skippyIter := &c.iterInput
 	pos := skippyIter.idx
 	set := inner.PairSets[index]
-	record := set.FindGlyph(gID(buffer.Info[skippyIter.idx].Glyph))
-	if record == nil {
+	record, ok := set.FindGlyph(gID(buffer.Info[skippyIter.idx].Glyph))
+	if !ok {
 		buffer.unsafeToConcat(buffer.idx, pos+1)
 		return false
 	}

--- a/opentype/tables/ot_properties.go
+++ b/opentype/tables/ot_properties.go
@@ -215,13 +215,13 @@ func (lk ExtensionPos) Cov() Coverage         { return nil } // not used anyway
 
 // FindGlyph performs a binary search in the list, returning the record for `secondGlyph`,
 // or `nil` if not found.
-func (ps PairSet) FindGlyph(secondGlyph GlyphID) *PairValueRecord {
+func (ps PairSet) FindGlyph(secondGlyph GlyphID) (PairValueRecord, bool) {
 	low, high := 0, int(ps.pairValueCount)
 	for low < high {
 		mid := low + (high-low)/2 // avoid overflow when computing mid
 		rec, err := ps.data.get(mid)
 		if err != nil { // argh...
-			return nil
+			return PairValueRecord{}, false
 		}
 		p := rec.SecondGlyph
 		if secondGlyph < p {
@@ -229,10 +229,10 @@ func (ps PairSet) FindGlyph(secondGlyph GlyphID) *PairValueRecord {
 		} else if secondGlyph > p {
 			low = mid + 1
 		} else {
-			return &rec
+			return rec, true
 		}
 	}
-	return nil
+	return PairValueRecord{}, false
 }
 
 // GetDelta returns the hint for the given `ppem`, scaled by `scale`.


### PR DESCRIPTION
During some benchmarks, I found `tables.PairSet.FindGlyph` was a really high source of heap allocations.
Using a plain struct (probably) allows the compiler/runtime to allocate it on the stack, resulting in a sizable reduction of heap allocations.