### PR TITLE
[harfbuzz] Properly scale glyph X and Y offsets

### DIFF
--- a/harfbuzz/fonts.go
+++ b/harfbuzz/fonts.go
@@ -208,11 +208,12 @@ func (f *Font) getGlyphHOriginWithFallback(glyph GID) (Position, Position) {
 	if !ok {
 		x, y, ok = f.face.GlyphVOrigin(glyph)
 		if ok {
+			x, y := f.emScalefX(float32(x)), f.emScalefY(float32(y))
 			dx, dy := f.guessVOriginMinusHOrigin(glyph)
 			return x - dx, y - dy
 		}
 	}
-	return x, y
+	return f.emScalefX(float32(x)), f.emScalefY(float32(y))
 }
 
 func (f *Font) getGlyphVOriginWithFallback(glyph GID) (Position, Position) {
@@ -220,11 +221,12 @@ func (f *Font) getGlyphVOriginWithFallback(glyph GID) (Position, Position) {
 	if !ok {
 		x, y, ok = f.face.GlyphHOrigin(glyph)
 		if ok {
+			x, y := f.emScalefX(float32(x)), f.emScalefY(float32(y))
 			dx, dy := f.guessVOriginMinusHOrigin(glyph)
 			return x + dx, y + dy
 		}
 	}
-	return x, y
+	return f.emScalefX(float32(x)), f.emScalefY(float32(y))
 }
 
 func (f *Font) guessVOriginMinusHOrigin(glyph GID) (x, y Position) {

--- a/harfbuzz/harfbuzz_shape_test.go
+++ b/harfbuzz/harfbuzz_shape_test.go
@@ -22,6 +22,14 @@ import (
 
 func TestShapeExpected(t *testing.T) {
 	tests := collectTests(t)
+
+	// add tests based on the C++ binary
+	tests = append(tests,
+		// check we properly scale the offset values
+		newTestData(t, "", "perf_reference/fonts/Roboto-Regular.ttf;--direction=ttb --font-size=2000;U+0061,U+0062;[gid70=0@-544,-1700+0,-2343|gid71=1@-562,-1912+0,-2343]"),
+		newTestData(t, "", "perf_reference/fonts/Roboto-Regular.ttf;--direction=ttb --font-size=3000;U+0061,U+0062;[gid70=0@-816,-2550+0,-3515|gid71=1@-842,-2868+0,-3515]"),
+	)
+
 	fmt.Printf("Running %d tests...\n", len(tests))
 
 	for _, testD := range tests {


### PR DESCRIPTION
Previously, the user provided Size factor was not applied to the offsets.
This is particularly visible for vertical texts (the bug was found working on #124).