### PR TITLE
Update README.md about breaking changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 This library provides typesetting capabilities in pure Go. It is appropriate for use in GUI applications, and is shared by multiple Go UI toolkits including [Fyne](https://fyne.io) and [Gio](https://gioui.org).
 
-## Developpment cycles
+## Development cycle
 
-This project, although already used in production by UI toolkits, still evolves rapidly. As such, the library uses unstable versions v0.x.y : the breaking changes required will bump the minor version number (x); the bug fixes and performance improvements the patch number (y).
+This project, although already used in production by UI toolkits, still evolves rapidly. As such, the library uses unstable versions v0.x.y : the required breaking changes will bump the minor version number (x); the bug fixes and performance improvements the patch number (y).
 
 ## Review guidelines
  

--- a/README.md
+++ b/README.md
@@ -2,8 +2,12 @@
 
 This library provides typesetting capabilities in pure Go. It is appropriate for use in GUI applications, and is shared by multiple Go UI toolkits including [Fyne](https://fyne.io) and [Gio](https://gioui.org).
 
-## Review guidelines
+## Developpment cycles
 
+This project, although already used in production by UI toolkits, still evolves rapidly. As such, the library uses unstable versions v0.x.y : the breaking changes required will bump the minor version number (x); the bug fixes and performance improvements the patch number (y).
+
+## Review guidelines
+ 
 Go-text is a collaboration between many individuals and projects, it is important to us that
 designs and decisions are right for the broadest possible audience.
 As a result the project will always have 3 maintainers that represent different projects


### PR DESCRIPTION
As discussed on Slack, I've added a small note about breaking changes and  v0.x.y versions.

This should be tagged as v0.1.0. 

This also implies we will regularly group commits into tagged versions, fixing #99 