### PR TITLE
Update CI workflows to better match latest changes in Fyne

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -1,21 +1,24 @@
-on: [push, pull_request]
 name: Static Analysis
+on: [push, pull_request]
+permissions:
+  contents: read
+
 jobs:
-  test: 
+  static_analysis:
     runs-on: ubuntu-latest
     steps:
-    - name: Install Go
-      uses: actions/setup-go@v3
+    - uses: actions/checkout@v4
       with:
-        go-version: 1.19.x
+        persist-credentials: false
+    - uses: WillAbides/setup-go-faster@v1.13.0
+      with:
+        go-version: '1.21.x'
 
-    - name: Checkout code
-      uses: actions/checkout@v2
-    
+    - name: Install analysis tools
+      run: go install honnef.co/go/tools/cmd/staticcheck@v0.4.6
+
     - name: Vet
       run: go vet ./...
 
     - name: Staticcheck
-      run: |
-        go install honnef.co/go/tools/cmd/staticcheck@2023.1.3
-        staticcheck ./...
+      run: staticcheck ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,26 +1,26 @@
-on: [push, pull_request]
 name: Test
+on: [push, pull_request]
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.17.x, 1.19.x, 1.20.x]
+        go-version: [1.17.x, 1.20.x, 1.21.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     runs-on: ${{ matrix.os }}
     steps:
-    - name: Install Go
-      uses: actions/setup-go@v3
+    - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+    - uses: WillAbides/setup-go-faster@v1.13.0
       with:
         go-version: ${{ matrix.go-version }}
-
-    - name: Checkout code
-      uses: actions/checkout@v2
+    
+    - name: Test
+      run: go test ./...
     
     - name: Build without tests
       run: go build ./...
-      if: ${{ matrix.go-version == '1.14.x' }}
-
-    - name: Test
-      run: go test ./...
-      if: ${{ matrix.go-version != '1.14.x' }}


### PR DESCRIPTION
This updates the CI infrastructure to be more modern and up to date with my latest changes over at Fyne.
Some highlights:
- Stricter permissions for security reasons.
- Update checkout action for deprecation and security reasons.
- Faster setup of the Go toolchain.
- Tests no run with Go 1.17 as base (as `go.mod` specifies).
- All workflows run on newer Go versions.
- Latest version of staticcheck.

I also fixed some broken logic in the test workflow.