### PR TITLE
[opentype] sanitize invalid LangSys entries in GSUB/GPOS tables

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/go-text/typesetting
 go 1.17
 
 require (
-	github.com/go-text/typesetting-utils v0.0.0-20231211103740-d9332ae51f04
+	github.com/go-text/typesetting-utils v0.0.0-20240317173224-1986cbe96c66
 	golang.org/x/image v0.3.0
 	golang.org/x/text v0.9.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/go-text/typesetting-utils v0.0.0-20231204162240-fa4dc564ba79 h1:3yBOz
 github.com/go-text/typesetting-utils v0.0.0-20231204162240-fa4dc564ba79/go.mod h1:DDxDdQEnB70R8owOx3LVpEFvpMK9eeH1o2r0yZhFI9o=
 github.com/go-text/typesetting-utils v0.0.0-20231211103740-d9332ae51f04 h1:zBx+p/W2aQYtNuyZNcTfinWvXBQwYtDfme051PR/lAY=
 github.com/go-text/typesetting-utils v0.0.0-20231211103740-d9332ae51f04/go.mod h1:DDxDdQEnB70R8owOx3LVpEFvpMK9eeH1o2r0yZhFI9o=
+github.com/go-text/typesetting-utils v0.0.0-20240317173224-1986cbe96c66 h1:GUrm65PQPlhFSKjLPGOZNPNxLCybjzjYBzjfoBGaDUY=
+github.com/go-text/typesetting-utils v0.0.0-20240317173224-1986cbe96c66/go.mod h1:DDxDdQEnB70R8owOx3LVpEFvpMK9eeH1o2r0yZhFI9o=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=

--- a/harfbuzz/fonts_test.go
+++ b/harfbuzz/fonts_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/go-text/typesetting/language"
 	"github.com/go-text/typesetting/opentype/api/font"
 	tu "github.com/go-text/typesetting/opentype/testutils"
 )
@@ -258,4 +259,17 @@ func TestNames(t *testing.T) {
 	tu.Assert(t, ft.GlyphName(2) == "A")
 	/* beyond last glyph */
 	tu.Assert(t, ft.GlyphName(2000) == "")
+}
+
+func TestUnifont(t *testing.T) {
+	// https://github.com/go-text/typesetting/issues/140
+	ft := openFontFileTT(t, "bitmap/unifont-15.1.05.otf")
+
+	buf := NewBuffer()
+	buf.Props.Language = "en-us"
+	buf.Props.Script = language.Latin
+	buf.Props.Direction = LeftToRight
+	buf.AddRunes([]rune{'a'}, 0, 1)
+	font := NewFont(&font.Face{Font: ft})
+	buf.Shape(font, nil) // just check for crashes
 }


### PR DESCRIPTION
It seems some fonts have corrupted LangSys entries. This commit ignores out of range feature indices. 
For #140 