### PR TITLE
shaping: ensure all-whitespace strings are assigned a face

### DIFF
--- a/shaping/input.go
+++ b/shaping/input.go
@@ -361,7 +361,10 @@ func splitByFace(input Input, availableFaces Fontmap, buffer []Input) []Input {
 	currentInput := input
 	for i := input.RunStart; i < input.RunEnd; i++ {
 		r := input.Text[i]
-		if ignoreFaceChange(r) {
+		// We can safely ignore characters if we have a face or if there is more text,
+		// but we must force the choice of a face if we still don't have one and we reach
+		// the final rune. Otherwise strings like all-whitespace are never assigned a face.
+		if ignoreFaceChange(r) && (currentInput.Face != nil || i < input.RunEnd-1) {
 			// add the rune to the current input
 			continue
 		}

--- a/shaping/input_test.go
+++ b/shaping/input_test.go
@@ -228,6 +228,23 @@ func TestSplitByFontGlyphs(t *testing.T) {
 				},
 			},
 		},
+		{
+			"entirely whitespace",
+			args{
+				input: Input{
+					Text:     []rune("   "),
+					RunStart: 0, RunEnd: 3,
+				},
+				availableFaces: []font.Face{latinFont, arabicFont},
+			},
+			[]Input{
+				{
+					Text:     []rune("   "),
+					RunStart: 0, RunEnd: 3,
+					Face: latinFont,
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/shaping/input_test.go
+++ b/shaping/input_test.go
@@ -245,6 +245,23 @@ func TestSplitByFontGlyphs(t *testing.T) {
 				},
 			},
 		},
+		{
+			"no change on ending space",
+			args{
+				input: Input{
+					Text:     []rune(" غير الأحلام "),
+					RunStart: 0, RunEnd: len([]rune(" غير الأحلام ")),
+				},
+				availableFaces: []font.Face{latinFont, arabicFont},
+			},
+			[]Input{
+				{
+					Text:     []rune(" غير الأحلام "),
+					RunStart: 0, RunEnd: len([]rune(" غير الأحلام ")),
+					Face: arabicFont,
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This commit ensures that strings of only whitespace runes (and other ignorable runes for the purposes of face selection) are actually assigned a face at all. The prior code could accidentally leave the face nil for inputs of all whitespace, resulting in unexpected line metrics for the whitespace.

I'd like to cherry pick this onto v0.1.0 to create v0.1.1. That's why this changeset is based on v0.1.0 instead of main.