### PR TITLE
[font] Add a glyph extents cache

### DIFF
--- a/font/cache.go
+++ b/font/cache.go
@@ -16,6 +16,9 @@ func (ec extentsCache) get(gid GID) (GlyphExtents, bool) {
 }
 
 func (ec extentsCache) set(gid GID, extents GlyphExtents) {
+	if int(gid) >= len(ec) {
+		return
+	}
 	ec[gid].valid = true
 	ec[gid].extents = extents
 }

--- a/font/cache.go
+++ b/font/cache.go
@@ -1,0 +1,38 @@
+package font
+
+type glyphExtents struct {
+	valid   bool
+	extents GlyphExtents
+}
+
+type extentsCache []glyphExtents
+
+func (ec extentsCache) get(gid GID) (GlyphExtents, bool) {
+	if int(gid) >= len(ec) {
+		return GlyphExtents{}, false
+	}
+	ge := ec[gid]
+	return ge.extents, ge.valid
+}
+
+func (ec extentsCache) set(gid GID, extents GlyphExtents) {
+	ec[gid].valid = true
+	ec[gid].extents = extents
+}
+
+func (ec extentsCache) reset() {
+	for i := range ec {
+		ec[i] = glyphExtents{}
+	}
+}
+
+func (f *Face) GlyphExtents(glyph GID) (GlyphExtents, bool) {
+	if e, ok := f.extentsCache.get(glyph); ok {
+		return e, ok
+	}
+	e, ok := f.glyphExtentsRaw(glyph)
+	if ok {
+		f.extentsCache.set(glyph, e)
+	}
+	return e, ok
+}

--- a/font/glyphs.go
+++ b/font/glyphs.go
@@ -77,7 +77,7 @@ func (f *Face) getPointsForGlyph(gid tables.GlyphID, currentDepth int, allPoints
 	phantoms[phantomBottom].Y = vOrig - vAdv
 
 	if f.isVar() {
-		f.gvar.applyDeltasToPoints(gid, f.Coords, points)
+		f.gvar.applyDeltasToPoints(gid, f.coords, points)
 	}
 
 	switch data := g.Data.(type) {

--- a/font/metrics.go
+++ b/font/metrics.go
@@ -98,9 +98,9 @@ func (f *Face) FontHExtents() (FontExtents, bool) {
 		out           FontExtents
 		ok1, ok2, ok3 bool
 	)
-	out.Ascender, ok1 = f.Font.getPositionCommon(metricsTagHorizontalAscender, f.Coords)
-	out.Descender, ok2 = f.Font.getPositionCommon(metricsTagHorizontalDescender, f.Coords)
-	out.LineGap, ok3 = f.Font.getPositionCommon(metricsTagHorizontalLineGap, f.Coords)
+	out.Ascender, ok1 = f.Font.getPositionCommon(metricsTagHorizontalAscender, f.coords)
+	out.Descender, ok2 = f.Font.getPositionCommon(metricsTagHorizontalDescender, f.coords)
+	out.LineGap, ok3 = f.Font.getPositionCommon(metricsTagHorizontalLineGap, f.coords)
 	return out, ok1 && ok2 && ok3
 }
 
@@ -110,9 +110,9 @@ func (f *Face) FontVExtents() (FontExtents, bool) {
 		out           FontExtents
 		ok1, ok2, ok3 bool
 	)
-	out.Ascender, ok1 = f.Font.getPositionCommon(metricsTagVerticalAscender, f.Coords)
-	out.Descender, ok2 = f.Font.getPositionCommon(metricsTagVerticalDescender, f.Coords)
-	out.LineGap, ok3 = f.Font.getPositionCommon(metricsTagVerticalLineGap, f.Coords)
+	out.Ascender, ok1 = f.Font.getPositionCommon(metricsTagVerticalAscender, f.coords)
+	out.Descender, ok2 = f.Font.getPositionCommon(metricsTagVerticalDescender, f.coords)
+	out.LineGap, ok3 = f.Font.getPositionCommon(metricsTagVerticalLineGap, f.coords)
 	return out, ok1 && ok2 && ok3
 }
 
@@ -134,27 +134,27 @@ var (
 func (f *Face) LineMetric(metric LineMetric) float32 {
 	switch metric {
 	case UnderlinePosition:
-		return f.post.underlinePosition + f.mvar.getVar(tagUnderlineOffset, f.Coords)
+		return f.post.underlinePosition + f.mvar.getVar(tagUnderlineOffset, f.coords)
 	case UnderlineThickness:
-		return f.post.underlineThickness + f.mvar.getVar(tagUnderlineSize, f.Coords)
+		return f.post.underlineThickness + f.mvar.getVar(tagUnderlineSize, f.coords)
 	case StrikethroughPosition:
-		return float32(f.os2.yStrikeoutPosition) + f.mvar.getVar(tagStrikeoutOffset, f.Coords)
+		return float32(f.os2.yStrikeoutPosition) + f.mvar.getVar(tagStrikeoutOffset, f.coords)
 	case StrikethroughThickness:
-		return float32(f.os2.yStrikeoutSize) + f.mvar.getVar(tagStrikeoutSize, f.Coords)
+		return float32(f.os2.yStrikeoutSize) + f.mvar.getVar(tagStrikeoutSize, f.coords)
 	case SuperscriptEmYSize:
-		return float32(f.os2.ySuperscriptYSize) + f.mvar.getVar(tagSuperscriptYSize, f.Coords)
+		return float32(f.os2.ySuperscriptYSize) + f.mvar.getVar(tagSuperscriptYSize, f.coords)
 	case SuperscriptEmXOffset:
-		return float32(f.os2.ySuperscriptXOffset) + f.mvar.getVar(tagSuperscriptXOffset, f.Coords)
+		return float32(f.os2.ySuperscriptXOffset) + f.mvar.getVar(tagSuperscriptXOffset, f.coords)
 	case SubscriptEmYSize:
-		return float32(f.os2.ySubscriptYSize) + f.mvar.getVar(tagSubscriptYSize, f.Coords)
+		return float32(f.os2.ySubscriptYSize) + f.mvar.getVar(tagSubscriptYSize, f.coords)
 	case SubscriptEmYOffset:
-		return float32(f.os2.ySubscriptYOffset) + f.mvar.getVar(tagSubscriptYOffset, f.Coords)
+		return float32(f.os2.ySubscriptYOffset) + f.mvar.getVar(tagSubscriptYOffset, f.coords)
 	case SubscriptEmXOffset:
-		return float32(f.os2.ySubscriptXOffset) + f.mvar.getVar(tagSubscriptXOffset, f.Coords)
+		return float32(f.os2.ySubscriptXOffset) + f.mvar.getVar(tagSubscriptXOffset, f.coords)
 	case CapHeight:
-		return float32(f.os2.sCapHeight) + f.mvar.getVar(tagCapHeight, f.Coords)
+		return float32(f.os2.sCapHeight) + f.mvar.getVar(tagCapHeight, f.coords)
 	case XHeight:
-		return float32(f.os2.sxHeigh) + f.mvar.getVar(tagXHeight, f.Coords)
+		return float32(f.os2.sxHeigh) + f.mvar.getVar(tagXHeight, f.coords)
 	default:
 		return 0
 	}
@@ -233,14 +233,14 @@ func (f *Face) HorizontalAdvance(gid GID) float32 {
 		return float32(advance)
 	}
 	if f.hvar != nil {
-		return float32(advance) + getAdvanceDeltaUnscaled(f.hvar, gID(gid), f.Coords)
+		return float32(advance) + getAdvanceDeltaUnscaled(f.hvar, gID(gid), f.coords)
 	}
 	return f.getGlyphAdvanceVar(gID(gid), false)
 }
 
 // return `true` is the font is variable and `Coords` is valid
 func (f *Face) isVar() bool {
-	return len(f.Coords) != 0 && len(f.Coords) == len(f.Font.fvar)
+	return len(f.coords) != 0 && len(f.coords) == len(f.Font.fvar)
 }
 
 // HasVerticalMetrics returns true if a the 'vmtx' table is present.
@@ -255,7 +255,7 @@ func (f *Face) VerticalAdvance(gid GID) float32 {
 		return -float32(advance)
 	}
 	if f.vvar != nil {
-		return -float32(advance) - getAdvanceDeltaUnscaled(f.vvar, gID(gid), f.Coords)
+		return -float32(advance) - getAdvanceDeltaUnscaled(f.vvar, gID(gid), f.coords)
 	}
 	return -f.getGlyphAdvanceVar(gID(gid), true)
 }
@@ -276,7 +276,7 @@ func (f *Face) getVerticalSideBearing(glyph gID) int16 {
 		return sideBearing
 	}
 	if f.vvar != nil {
-		return sideBearing + int16(getLsbDeltaUnscaled(f.vvar, glyph, f.Coords))
+		return sideBearing + int16(getLsbDeltaUnscaled(f.vvar, glyph, f.coords))
 	}
 	return f.getGlyphSideBearingVar(glyph, true)
 }
@@ -390,15 +390,15 @@ func (f *Face) getExtentsFromCff2(glyph gID) (GlyphExtents, bool) {
 	if f.cff2 == nil {
 		return GlyphExtents{}, false
 	}
-	_, bounds, err := f.cff2.LoadGlyph(glyph, f.Coords)
+	_, bounds, err := f.cff2.LoadGlyph(glyph, f.coords)
 	if err != nil {
 		return GlyphExtents{}, false
 	}
 	return bounds.ToExtents(), true
 }
 
-func (f *Face) GlyphExtents(glyph GID) (GlyphExtents, bool) {
-	out, ok := f.getExtentsFromSbix(gID(glyph), f.XPpem, f.YPpem)
+func (f *Face) glyphExtentsRaw(glyph GID) (GlyphExtents, bool) {
+	out, ok := f.getExtentsFromSbix(gID(glyph), f.xPpem, f.yPpem)
 	if ok {
 		return out, ok
 	}
@@ -414,6 +414,6 @@ func (f *Face) GlyphExtents(glyph GID) (GlyphExtents, bool) {
 	if ok {
 		return out, ok
 	}
-	out, ok = f.getExtentsFromBitmap(gID(glyph), f.XPpem, f.YPpem)
+	out, ok = f.getExtentsFromBitmap(gID(glyph), f.xPpem, f.yPpem)
 	return out, ok
 }

--- a/font/renderer.go
+++ b/font/renderer.go
@@ -109,7 +109,7 @@ type BitmapSize struct {
 // not found.
 func (f *Face) GlyphData(gid GID) GlyphData {
 	// since outline may be specified for SVG and bitmaps, check it at the end
-	outB, err := f.sbix.glyphData(gID(gid), f.XPpem, f.YPpem)
+	outB, err := f.sbix.glyphData(gID(gid), f.xPpem, f.yPpem)
 	if err == nil {
 		outline, ok := f.outlineGlyphData(gID(gid))
 		if ok {
@@ -118,7 +118,7 @@ func (f *Face) GlyphData(gid GID) GlyphData {
 		return outB
 	}
 
-	outB, err = f.bitmap.glyphData(gID(gid), f.XPpem, f.YPpem)
+	outB, err = f.bitmap.glyphData(gID(gid), f.xPpem, f.yPpem)
 	if err == nil {
 		outline, ok := f.outlineGlyphData(gID(gid))
 		if ok {
@@ -401,7 +401,7 @@ func (f *Face) glyphDataFromCFF2(glyph gID) (GlyphOutline, error) {
 	if f.cff2 == nil {
 		return GlyphOutline{}, errNoCFF2Table
 	}
-	segments, _, err := f.cff2.LoadGlyph(glyph, f.Coords)
+	segments, _, err := f.cff2.LoadGlyph(glyph, f.coords)
 	if err != nil {
 		return GlyphOutline{}, err
 	}

--- a/font/renderer_test.go
+++ b/font/renderer_test.go
@@ -505,14 +505,14 @@ func TestGlyphDataCrash(t *testing.T) {
 
 func TestSbixGlyph(t *testing.T) {
 	ft := loadFont(t, "toys/Feat.ttf")
-	face := Face{Font: ft, XPpem: 100, YPpem: 100}
+	face := Face{Font: ft, xPpem: 100, yPpem: 100}
 	data := face.GlyphData(1)
 	asBitmap, ok := data.(GlyphBitmap)
 	tu.Assert(t, ok)
 	tu.Assert(t, asBitmap.Format == PNG)
 
 	ft = loadFont(t, "toys/Sbix3.ttf")
-	face = Face{Font: ft, XPpem: 100, YPpem: 100}
+	face = Face{Font: ft, xPpem: 100, yPpem: 100}
 	data = face.GlyphData(4)
 	asBitmap, ok = data.(GlyphBitmap)
 	tu.Assert(t, ok)
@@ -522,7 +522,7 @@ func TestSbixGlyph(t *testing.T) {
 func TestCblcGlyph(t *testing.T) {
 	for _, filename := range td.WithCBLC {
 		font := loadFont(t, filename.Path)
-		face := Face{Font: font, XPpem: 94, YPpem: 94}
+		face := Face{Font: font, xPpem: 94, yPpem: 94}
 
 		for gid := filename.GlyphRange[0]; gid <= filename.GlyphRange[1]; gid++ {
 			data := face.GlyphData(GID(gid))
@@ -579,7 +579,7 @@ func TestAppleBitmapGlyph(t *testing.T) {
 	ft, err := NewFont(fonts[0])
 	tu.AssertNoErr(t, err)
 
-	face := Face{Font: ft, XPpem: 94, YPpem: 94}
+	face := Face{Font: ft, xPpem: 94, yPpem: 94}
 
 	runes := "The quick brown fox jumps over the lazy dog"
 	for _, r := range runes {
@@ -601,7 +601,7 @@ func TestMixedGlyphs(t *testing.T) {
 		font := loadFont(t, filename)
 		space, ok := font.NominalGlyph(' ')
 		tu.Assert(t, ok)
-		face := Face{Font: font, XPpem: 94, YPpem: 94}
+		face := Face{Font: font, xPpem: 94, yPpem: 94}
 
 		gd := face.GlyphData(space)
 		tu.Assert(t, gd != nil)

--- a/font/variations.go
+++ b/font/variations.go
@@ -516,19 +516,19 @@ type Variation struct {
 // Note that passing an empty slice will instead remove the coordinates.
 func (face *Face) SetVariations(variations []Variation) {
 	if len(variations) == 0 {
-		face.Coords = nil
+		face.SetCoords(nil)
 		return
 	}
 
 	fv := face.Font.fvar
 	if len(fv) == 0 { // the font is not variable...
-		face.Coords = nil
+		face.SetCoords(nil)
 		return
 	}
 
 	designCoords := fv.getDesignCoordsDefault(variations)
 
-	face.Coords = face.Font.NormalizeVariations(designCoords)
+	face.SetCoords(face.NormalizeVariations(designCoords))
 }
 
 // getDesignCoordsDefault returns the design coordinates corresponding to the given pairs of axis/value.

--- a/font/variations_test.go
+++ b/font/variations_test.go
@@ -42,11 +42,11 @@ func TestVar(t *testing.T) {
 
 	face := Face{Font: font}
 	face.SetVariations([]Variation{{ot.MustNewTag("wght"), 206.}})
-	tu.Assert(t, len(face.Coords) == 1)
-	tu.Assert(t, face.Coords[0] == -16117)
+	tu.Assert(t, len(face.coords) == 1)
+	tu.Assert(t, face.coords[0] == -16117)
 
 	face.SetVariations(nil)
-	tu.Assert(t, len(face.Coords) == 0)
+	tu.Assert(t, len(face.coords) == 0)
 
 	font = loadFont(t, "common/NotoSansCJKjp-VF.otf")
 	for _, test := range []struct {
@@ -75,7 +75,8 @@ func TestGlyphExtentsVar(t *testing.T) {
 		{900, GlyphExtents{XBearing: 44, YBearing: 662, Width: 630, Height: -674}},
 	} {
 		coords := font.NormalizeVariations([]float32{test.coord})
-		face := Face{Font: font, Coords: coords}
+		face := NewFace(font)
+		face.coords = coords
 
 		ext, _ := face.GlyphExtents(2)
 

--- a/fontscan/fontmap_test.go
+++ b/fontscan/fontmap_test.go
@@ -50,7 +50,7 @@ func ExampleFontMap_AddFace() {
 	f, _ := font.NewFont(ld)        // error handling omitted
 	md := f.Describe()
 	fontMap := NewFontMap(log.Default())
-	fontMap.AddFace(&font.Face{Font: f}, Location{File: fmt.Sprint(md)}, md)
+	fontMap.AddFace(font.NewFace(f), Location{File: fmt.Sprint(md)}, md)
 
 	// set the font description
 	fontMap.SetQuery(Query{Families: []string{"Arial", "serif"}}) // regular Aspect

--- a/fontscan/footprint.go
+++ b/fontscan/footprint.go
@@ -124,5 +124,5 @@ func (fp *Footprint) loadFromDisk() (*font.Face, error) {
 		return nil, fmt.Errorf("reading font at %s: %s", location.File, err)
 	}
 
-	return &font.Face{Font: ft}, nil
+	return font.NewFace(ft), nil
 }

--- a/harfbuzz/fonts.go
+++ b/harfbuzz/fonts.go
@@ -90,7 +90,7 @@ func NewFont(face Face) *Font {
 // SetVarCoordsDesign applies a list of variation coordinates, in design-space units,
 // to the font.
 func (f *Font) SetVarCoordsDesign(coords []float32) {
-	f.face.Coords = f.face.NormalizeVariations(coords)
+	f.face.SetCoords(f.face.NormalizeVariations(coords))
 }
 
 // Face returns the underlying face.
@@ -310,12 +310,13 @@ func (f *Font) ExtentsForDirection(direction Direction) font.FontExtents {
 	return extents
 }
 
-func (font *Font) varCoords() []tables.Coord { return font.face.Coords }
+func (font *Font) varCoords() []tables.Coord { return font.face.Coords() }
 
 func (font *Font) getXDelta(varStore tables.ItemVarStore, device tables.DeviceTable) Position {
 	switch device := device.(type) {
 	case tables.DeviceHinting:
-		return device.GetDelta(font.face.XPpem, font.XScale)
+		xPpem, _ := font.face.Ppem()
+		return device.GetDelta(xPpem, font.XScale)
 	case tables.DeviceVariation:
 		return font.emScalefX(varStore.GetDelta(tables.VariationStoreIndex(device), font.varCoords()))
 	default:
@@ -326,7 +327,8 @@ func (font *Font) getXDelta(varStore tables.ItemVarStore, device tables.DeviceTa
 func (font *Font) getYDelta(varStore tables.ItemVarStore, device tables.DeviceTable) Position {
 	switch device := device.(type) {
 	case tables.DeviceHinting:
-		return device.GetDelta(font.face.YPpem, font.YScale)
+		_, yPpem := font.face.Ppem()
+		return device.GetDelta(yPpem, font.YScale)
 	case tables.DeviceVariation:
 		return font.emScalefY(varStore.GetDelta(tables.VariationStoreIndex(device), font.varCoords()))
 	default:

--- a/harfbuzz/fonts_test.go
+++ b/harfbuzz/fonts_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestExtentsTtVar(t *testing.T) {
 	ft := openFontFile(t, "fonts/SourceSansVariable-Roman-nohvar-41,C1.ttf")
-	font := NewFont(&font.Face{Font: ft})
+	font := NewFont(font.NewFace(ft))
 
 	extents, result := font.GlyphExtents(2)
 	tu.Assert(t, result)
@@ -38,7 +38,7 @@ func TestExtentsTtVar(t *testing.T) {
 
 func TestAdvanceTtVarNohvar(t *testing.T) {
 	ft := openFontFile(t, "fonts/SourceSansVariable-Roman-nohvar-41,C1.ttf")
-	font := NewFont(&font.Face{Font: ft})
+	font := NewFont(font.NewFace(ft))
 
 	x, y := font.GlyphAdvanceForDirection(2, LeftToRight)
 
@@ -64,7 +64,7 @@ func TestAdvanceTtVarNohvar(t *testing.T) {
 
 func TestAdvanceTtVarHvarvvar(t *testing.T) {
 	ft := openFontFile(t, "fonts/SourceSerifVariable-Roman-VVAR.abc.ttf")
-	font := NewFont(&font.Face{Font: ft})
+	font := NewFont(font.NewFace(ft))
 
 	x, y := font.GlyphAdvanceForDirection(1, LeftToRight)
 
@@ -91,7 +91,7 @@ func TestAdvanceTtVarHvarvvar(t *testing.T) {
 
 func TestAdvanceTtVarAnchor(t *testing.T) {
 	ft := openFontFile(t, "fonts/SourceSansVariable-Roman.anchor.ttf")
-	font := NewFont(&font.Face{Font: ft})
+	font := NewFont(font.NewFace(ft))
 
 	extents, result := font.GlyphExtents(2)
 	tu.Assert(t, result)
@@ -114,7 +114,7 @@ func TestAdvanceTtVarAnchor(t *testing.T) {
 
 func TestExtentsTtVarComp(t *testing.T) {
 	ft := openFontFile(t, "fonts/SourceSansVariable-Roman.modcomp.ttf")
-	font := NewFont(&font.Face{Font: ft})
+	font := NewFont(font.NewFace(ft))
 
 	coords := []float32{800.0}
 	font.SetVarCoordsDesign(coords)
@@ -146,7 +146,7 @@ func TestExtentsTtVarComp(t *testing.T) {
 
 func TestAdvanceTtVarCompV(t *testing.T) {
 	ft := openFontFile(t, "fonts/SourceSansVariable-Roman.modcomp.ttf")
-	font := NewFont(&font.Face{Font: ft})
+	font := NewFont(font.NewFace(ft))
 
 	coords := []float32{800.0}
 	font.SetVarCoordsDesign(coords)
@@ -166,7 +166,8 @@ func TestAdvanceTtVarGvarInfer(t *testing.T) {
 	ft := openFontFile(t, "fonts/TestGVAREight.ttf")
 	coords := []font.VarCoord{100}
 
-	face := &font.Face{Font: ft, Coords: coords}
+	face := font.NewFace(ft)
+	face.SetCoords(coords)
 	font := NewFont(face)
 	_, ok := font.GlyphExtents(4)
 	tu.Assert(t, ok)
@@ -174,7 +175,7 @@ func TestAdvanceTtVarGvarInfer(t *testing.T) {
 
 func TestLigCarets(t *testing.T) {
 	ft := openFontFile(t, "fonts/NotoNastaliqUrdu-Regular.ttf")
-	font := NewFont(&font.Face{Font: ft})
+	font := NewFont(font.NewFace(ft))
 	font.XScale, font.YScale = int32(ft.Upem())*2, int32(ft.Upem())*4
 
 	/* call with no result */
@@ -217,7 +218,7 @@ func TestColorGlyphExtents(t *testing.T) {
 	 * 0,0,0,0 and not meaningless numbers.
 	 */
 	ft := openFontFile(t, "fonts/adwaita.ttf")
-	font := NewFont(&font.Face{Font: ft})
+	font := NewFont(font.NewFace(ft))
 
 	for _, test := range []struct {
 		gid     GID
@@ -270,6 +271,6 @@ func TestUnifont(t *testing.T) {
 	buf.Props.Script = language.Latin
 	buf.Props.Direction = LeftToRight
 	buf.AddRunes([]rune{'a'}, 0, 1)
-	font := NewFont(&font.Face{Font: ft})
+	font := NewFont(font.NewFace(ft))
 	buf.Shape(font, nil) // just check for crashes
 }

--- a/harfbuzz/harbuzz_test.go
+++ b/harfbuzz/harbuzz_test.go
@@ -179,7 +179,7 @@ func TestExample(t *testing.T) {
 	runes := []rune{0x0633, 0x064F, 0x0644, 0x064E, 0x0651, 0x0627, 0x0651, 0x0650, 0x0645, 0x062A, 0x06CC}
 	buffer.AddRunes(runes, 0, -1)
 
-	face := &font.Face{Font: ft}
+	face := font.NewFace(ft)
 	font := NewFont(face)
 	buffer.GuessSegmentProperties()
 	buffer.Shape(font, nil)

--- a/harfbuzz/harfbuzz_shape_test.go
+++ b/harfbuzz/harfbuzz_shape_test.go
@@ -127,10 +127,11 @@ func (fo *fontOpts) loadFont(t *testing.T) *Font {
 	tu.AssertNoErr(t, err)
 
 	// create the face
-	face := font.Face{Font: ft, XPpem: fo.xPpem, YPpem: fo.yPpem}
+	face := font.NewFace(ft)
+	face.SetPpem(fo.xPpem, fo.yPpem)
 	face.SetVariations(fo.variations)
 
-	font := NewFont(&face)
+	font := NewFont(face)
 
 	if fo.fontSizeX == fontSizeUpem {
 		fo.fontSizeX = int(font.faceUpem)

--- a/harfbuzz/ot_layout_gpos.go
+++ b/harfbuzz/ot_layout_gpos.go
@@ -227,8 +227,9 @@ func (c *otApplyContext) applyGPOSValueRecord(format tables.ValueFormat, v table
 		return ret
 	}
 
-	useXDevice := font.face.XPpem != 0 || len(font.varCoords()) != 0
-	useYDevice := font.face.YPpem != 0 || len(font.varCoords()) != 0
+	xp, yp := font.face.Ppem()
+	useXDevice := xp != 0 || len(font.varCoords()) != 0
+	useYDevice := yp != 0 || len(font.varCoords()) != 0
 
 	if !useXDevice && !useYDevice {
 		return ret
@@ -463,7 +464,7 @@ func (c *otApplyContext) getAnchor(anchor tables.Anchor, glyph GID) (x, y float3
 	case tables.AnchorFormat1:
 		return font.emFscaleX(anchor.XCoordinate), font.emFscaleY(anchor.YCoordinate)
 	case tables.AnchorFormat2:
-		xPpem, yPpem := font.face.XPpem, font.face.YPpem
+		xPpem, yPpem := font.face.Ppem()
 		var cx, cy Position
 		ret := xPpem != 0 || yPpem != 0
 		if ret {
@@ -481,11 +482,12 @@ func (c *otApplyContext) getAnchor(anchor tables.Anchor, glyph GID) (x, y float3
 		}
 		return x, y
 	case tables.AnchorFormat3:
+		xPpem, yPpem := font.face.Ppem()
 		x, y = font.emFscaleX(anchor.XCoordinate), font.emFscaleY(anchor.YCoordinate)
-		if font.face.XPpem != 0 || len(font.varCoords()) != 0 {
+		if xPpem != 0 || len(font.varCoords()) != 0 {
 			x += float32(font.getXDelta(c.varStore, anchor.XDevice))
 		}
-		if font.face.YPpem != 0 || len(font.varCoords()) != 0 {
+		if yPpem != 0 || len(font.varCoords()) != 0 {
 			y += float32(font.getYDelta(c.varStore, anchor.YDevice))
 		}
 		return x, y

--- a/harfbuzz/shaper_perf_test.go
+++ b/harfbuzz/shaper_perf_test.go
@@ -76,7 +76,7 @@ func BenchmarkShaping(b *testing.B) {
 func shapeOne(b *testing.B, textFile, fontFile string, direction Direction, script language.Script) {
 	ft := openFontFile(b, fontFile)
 
-	font := NewFont(&font.Face{Font: ft})
+	font := NewFont(font.NewFace(ft))
 
 	textB, err := ioutil.ReadFile(textFile)
 	tu.AssertNoErr(b, err)

--- a/shaping/shaping_test.go
+++ b/shaping/shaping_test.go
@@ -450,11 +450,15 @@ func TestFontLoadHeapSize(t *testing.T) {
 		},
 	} {
 		onDiskSize := len(bc.fontData)
-		allocBefore := heapSize()
-		face, _ := font.ParseTTF(bytes.NewReader(bc.fontData))
-		allocAfter := heapSize()
-		additionnalAlloc := allocAfter - allocBefore
-		fmt.Printf("%s On disk: %v KB, additional memory: %v KB\n", bc.name, onDiskSize/1024, additionnalAlloc/1024)
+		hs := heapSize()
+
+		loader, _ := ot.NewLoader(bytes.NewReader(bc.fontData))
+		ft, _ := font.NewFont(loader)
+		fontSize := heapSize() - hs
+		hs = heapSize()
+		face := font.NewFace(ft)
+		faceSize := heapSize() - hs
+		fmt.Printf("%s On disk: %v KB, font memory: %v KB, face memory %v KB\n", bc.name, onDiskSize/1024, fontSize/1024, faceSize/1024)
 		_ = face.Upem()
 	}
 }


### PR DESCRIPTION
I've noticed typesetting shows somewhat poor performance when using fonts with CFF tables (usually marked with an .otf extension).

A quick benchmark revealed that the bottleneck is in the `[Face.GlyphExtents]` method, which is called (in `HarbuffShaper.Shape`) for every glyph.
Contrary to the 'glyf' table used in Truetype font files, CFF tables do not expose this metrics : we have to parse the whole glyph to compute it. 
The issue will also arise with variable fonts, for which we also have to apply the variations to the glyph description in order to compute its extents. 

Thus, I propose to add a cache for glyph extents to the `[Face]` struct. 

The following benchmark shows a net improvement for CFF tables (Raleway-v4020-Regular.otf) and variable fonts (Commissioner-VF.ttf#01). 
Performances for Truetype (DejaVuSans.ttf) or variable fonts with no variations activated (Commissioner-VF.ttf) are unchanged.


|   | old.txt | new.txt   |
| :---         |     :---:      |          ---: | 
| DejaVuSans.ttf-4            |  1.200m ± 15% |   1.145m ± 2%   -4.57% (p=0.000 n=10)  |
| Raleway-v4020-Regular.otf-4 | 11.293m ± 15% |   2.315m ± 1%  -79.50% (p=0.000 n=10)  |
| Commissioner-VF.ttf-4       |  2.412m ±  5% |   2.364m ± 5%   -2.01% (p=0.019 n=10)  |
| Commissioner-VF.ttf#01-4    | 15.231m ±  2% |   2.500m ± 2%  -83.59% (p=0.000 n=10)  |
 
The side effect of this change is that fields on `[Face] `now require setters (since updating them will usually change the glyph extents). Also, I've added a constructor (`[NewFace]`) to initialize the cache.
The other change for users is that, now, a `[Face]` should be stored and reused, whereas it was previously a cheap object which could be short-lived.

