### PR TITLE
[harfbuzz] reuse shaperOpentype instead of allocating a new one

### DIFF
--- a/harfbuzz/ot_shaper.go
+++ b/harfbuzz/ot_shaper.go
@@ -763,14 +763,13 @@ type shaperOpentype struct {
 
 type otShapePlanKey = [2]int // -1 for not found
 
-func newShaperOpentype(tables *font.Font, coords []tables.Coord) *shaperOpentype {
-	var out shaperOpentype
-	out.key = otShapePlanKey{
+func (sp *shaperOpentype) init(tables *font.Font, coords []tables.Coord) {
+	sp.plan = otShapePlan{}
+	sp.key = otShapePlanKey{
 		0: tables.GSUB.FindVariationIndex(coords),
 		1: tables.GPOS.FindVariationIndex(coords),
 	}
-	out.tables = tables
-	return &out
+	sp.tables = tables
 }
 
 func (sp *shaperOpentype) compile(props SegmentProperties, userFeatures []Feature) {

--- a/harfbuzz/shape.go
+++ b/harfbuzz/shape.go
@@ -43,7 +43,7 @@ func (b *Buffer) Shape(font *Font, features []Feature) {
 //
 // Most client programs will not need to deal with shape plans directly.
 type shapePlan struct {
-	shaper       *shaperOpentype
+	shaper       shaperOpentype
 	props        SegmentProperties
 	userFeatures []Feature
 }
@@ -68,7 +68,7 @@ func (plan *shapePlan) init(copy bool, font *Font, props SegmentProperties,
 	}
 
 	// init shaper
-	plan.shaper = newShaperOpentype(font.face.Font, coords)
+	plan.shaper.init(font.face.Font, coords)
 }
 
 func (plan shapePlan) userFeaturesMatch(other shapePlan) bool {


### PR DESCRIPTION
This is a memory optimization : previously, the `shaper` field (with type `*shaperOpentype`) was allocated at each `harbuzz.Shape` call.

Removing the pointer and simply resetting the fields instead reduces memory usage. 

This is very similar to https://github.com/go-text/typesetting/pull/106