### PR TITLE
[font] expose LoadHeadTable

### DIFF
--- a/font/font.go
+++ b/font/font.go
@@ -212,7 +212,7 @@ func NewFont(ld *ot.Loader) (*Font, error) {
 		return nil, err
 	}
 
-	out.head, _, err = loadHeadTable(ld, nil)
+	out.head, _, err = LoadHeadTable(ld, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -347,13 +347,14 @@ func NewFont(ld *ot.Loader) (*Font, error) {
 
 var bhedTag = ot.MustNewTag("bhed")
 
-// loadHeadTable loads the table corresponding to the 'head' tag.
+// LoadHeadTable loads the 'head' or the 'bhed' table.
+//
 // If a 'bhed' Apple table is present, it replaces the 'head' one.
 //
-// 'buffer' may be provided to reduce allocations; the return Head is guaranteed
-// not to retain any reference on 'buffer'.
-// If 'buffer' is nil or has not enough capacity, a new slice is allocated (and returned).
-func loadHeadTable(ld *ot.Loader, buffer []byte) (tables.Head, []byte, error) {
+// [buffer] may be provided to reduce allocations; the returned [tables.Head] is guaranteed
+// not to retain any reference on [buffer].
+// If [buffer] is nil or has not enough capacity, a new slice is allocated (and returned).
+func LoadHeadTable(ld *ot.Loader, buffer []byte) (tables.Head, []byte, error) {
 	var err error
 	// check 'bhed' first
 	if ld.HasTable(bhedTag) {

--- a/font/metadata.go
+++ b/font/metadata.go
@@ -334,7 +334,7 @@ func newFontDescriptor(ld *ot.Loader, buffer []byte) (fontDescriptor, []byte) {
 		desc.os2 = newOS2Desc(os2)
 	}
 
-	desc.head, buffer, _ = loadHeadTable(ld, buffer)
+	desc.head, buffer, _ = LoadHeadTable(ld, buffer)
 
 	buffer, _ = ld.RawTableTo(ot.MustNewTag("name"), buffer)
 	desc.names, _, _ = tables.ParseName(buffer)

--- a/font/opentype/tables/head_src.go
+++ b/font/opentype/tables/head_src.go
@@ -5,6 +5,7 @@ package tables
 // TableHead contains critical information about the rest of the font.
 // https://learn.microsoft.com/en-us/typography/opentype/spec/head
 // https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6head.html
+// https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6bhed.html
 type Head struct {
 	majorVersion       uint16
 	minorVersion       uint16

--- a/font/variations_test.go
+++ b/font/variations_test.go
@@ -179,7 +179,7 @@ func TestInvalidGVAR(t *testing.T) {
 	ld, err := ot.NewLoader(f)
 	tu.AssertNoErr(t, err)
 
-	head, _, _ := loadHeadTable(ld, nil)
+	head, _, _ := LoadHeadTable(ld, nil)
 	raw, _ := ld.RawTable(ot.MustNewTag("maxp"))
 	maxp, _, _ := tables.ParseMaxp(raw)
 	raw, _ = ld.RawTable(ot.MustNewTag("glyf"))


### PR DESCRIPTION
When you want to process a font file, you have to parse the 'head' table first. The issue is that some macos bitmap fonts use the 'bhed' table instead.
We use an helper function `loadHeadTable` to handle this complexity. It may be used by libraries which want to manually inspect a font file, but it was hidden in #130 by mistake.

This PR fixes the issue and exposes this helper back.

This is backward compatible, with no changes for GUI toolkits end users.