### PR TITLE
[shaping] Trailing spaces

### DIFF
--- a/shaping/wrapping.go
+++ b/shaping/wrapping.go
@@ -838,12 +838,13 @@ func (l *LineWrapper) postProcessLine(finalLine Line, done bool) (WrappedLine, b
 		// zero trailing whitespace advance,
 		// to be coherent with Output.advanceSpaceAware
 		if L := len(finalRun.Glyphs); L != 0 {
+			g := &finalRun.Glyphs[L-1]
 			if finalRun.Direction.IsVertical() {
-				if g := &finalRun.Glyphs[L-1]; g.Height == 0 {
+				if g.Height == 0 {
 					g.YAdvance = 0
 				}
 			} else { // horizontal
-				if g := finalRun.Glyphs[L-1]; g.Width == 0 {
+				if g.Width == 0 {
 					g.XAdvance = 0
 				}
 			}


### PR DESCRIPTION
Due to a missing reference operator (&), the trailing whitespaces were not collapsed properly.

An interesting side effect of this change was to discover that some tests used one `Output` several times, without copying its glyphs, leading to spurious errors when the glyphs were mutated.
