### PR TITLE
Cap height fallback

### DIFF
--- a/font/font_test.go
+++ b/font/font_test.go
@@ -115,13 +115,9 @@ func TestMaxpAndHmtx(t *testing.T) {
 }
 
 func TestLoadCFF2(t *testing.T) {
-	b, err := td.Files.ReadFile("common/NotoSansCJKjp-VF.otf")
-	tu.AssertNoErr(t, err)
+	ld := readFontFile(t, "common/NotoSansCJKjp-VF.otf")
 
-	ft, err := ot.NewLoader(bytes.NewReader(b))
-	tu.AssertNoErr(t, err)
-
-	font, err := NewFont(ft)
+	font, err := NewFont(ld)
 	tu.AssertNoErr(t, err)
 
 	tu.Assert(t, font.cff2 != nil)

--- a/font/font_test.go
+++ b/font/font_test.go
@@ -123,3 +123,14 @@ func TestLoadCFF2(t *testing.T) {
 	tu.Assert(t, font.cff2 != nil)
 	tu.Assert(t, font.cff2.VarStore.AxisCount() == 1)
 }
+
+func TestCapHeight(t *testing.T) {
+	ld := readFontFile(t, "common/mplus-1p-regular.ttf")
+	font, err := NewFont(ld)
+	tu.AssertNoErr(t, err)
+	face := NewFace(font)
+
+	// reference values from Harfbuzz
+	tu.Assert(t, face.LineMetric(CapHeight) == 730)
+	tu.Assert(t, face.LineMetric(XHeight) == 520)
+}

--- a/shaping/spacing.go
+++ b/shaping/spacing.go
@@ -10,7 +10,7 @@ import (
 // Note that space is always added, even on boundaries.
 //
 // See also the convenience function [AddSpacing] to handle a slice of runs.
-
+//
 // See also https://www.w3.org/TR/css-text-3/#word-separator
 func (run *Output) AddWordSpacing(text []rune, additionalSpacing fixed.Int26_6) {
 	isVertical := run.Direction.IsVertical()


### PR DESCRIPTION
This PR adds a fallback required to retrieve cap-height and x-height values for older fonts (having a 'OS/2'  table with version older than 2). 

(The implementation follows x/image/font and harfbuzz references.)

For #169.