### PR TITLE
[fontmap] update Replacer for string normalization by handling null byte removal

### DIFF
--- a/font/metadata.go
+++ b/font/metadata.go
@@ -277,7 +277,7 @@ func (fd *fontDescriptor) rawAspect() Aspect {
 	return Aspect{style, weight, stretch}
 }
 
-var rp = strings.NewReplacer(" ", "", "\t", "")
+var rp = strings.NewReplacer(" ", "", "\t", "", "\x00", "")
 
 // NormalizeFamily removes spaces and lower the given string.
 func NormalizeFamily(family string) string { return rp.Replace(strings.ToLower(family)) }

--- a/fontscan/serialize.go
+++ b/fontscan/serialize.go
@@ -110,6 +110,7 @@ func (fp *Footprint) deserializeFrom(data []byte) (int, error) {
 	if err != nil {
 		return 0, err
 	}
+	fp.Family = font.NormalizeFamily(fp.Family)
 	n += read
 	read, err = fp.Runes.deserializeFrom(data[n:])
 	if err != nil {

--- a/fontscan/serialize_test.go
+++ b/fontscan/serialize_test.go
@@ -18,7 +18,7 @@ import (
 func Test_serializeFootprints(t *testing.T) {
 	input := []Footprint{
 		{
-			Family:  "a strange one",
+			Family:  font.NormalizeFamily("a strange \x00one"),
 			Runes:   newRuneSet(1, 0, 2, 0x789, 0xfffee),
 			Scripts: ScriptSet{0, 1, 5, 0xffffff, language.Nabataean, language.Unknown},
 			Aspect:  font.Aspect{Style: 1, Weight: 200, Stretch: 0.45},
@@ -71,7 +71,7 @@ func assertFontsetEquals(expected, got []Footprint) error {
 func TestSerializeDeserialize(t *testing.T) {
 	for _, fp := range []Footprint{
 		{
-			Family:  "a strange one",
+			Family:  font.NormalizeFamily("a strange \x00one"),
 			Runes:   newRuneSet(1, 0, 2, 0x789, 0xfffee),
 			Scripts: ScriptSet{0, 1, 5, 0xffffff},
 			Aspect:  font.Aspect{Style: 1, Weight: 200, Stretch: 0.45},


### PR DESCRIPTION
I have confirmed that the deserialized font family name contains `\x00` (e.g. MS Gothic).
This is why there is a problem with fontmap.FindSystemFonts() not matching even though the correct font name is specified.
This PR is one idea to address this problem, but where to put the normalization process may be debatable.