### PR TITLE
[font] Names decoding

### DIFF
--- a/font/metadata_test.go
+++ b/font/metadata_test.go
@@ -118,3 +118,14 @@ func TestAspectFromOS2(t *testing.T) {
 	inferred.inferFromStyle(fd.additionalStyle())
 	tu.Assert(t, inferred.Weight == 380)
 }
+
+func TestFamily(t *testing.T) {
+	f, err := td.Files.ReadFile("collections/msgothic.ttc")
+	tu.AssertNoErr(t, err)
+
+	faces, err := ParseTTC(bytes.NewReader(f))
+	tu.AssertNoErr(t, err)
+
+	tu.Assert(t, len(faces) == 3)
+	tu.Assert(t, faces[0].Describe().Family == "MS Gothic")
+}

--- a/font/opentype/tables/name_src.go
+++ b/font/opentype/tables/name_src.go
@@ -140,8 +140,9 @@ func (names Name) decodeRecord(n nameRecord) string {
 	}
 	value := names.stringData[n.stringOffset:end]
 
-	if n.platformID == PlatformUnicode || (n.platformID == PlatformMicrosoft &&
-		n.encodingID == PEMicrosoftUnicodeCs) {
+	if n.platformID == PlatformUnicode ||
+		(n.platformID == PlatformMicrosoft &&
+			(n.encodingID == PEMicrosoftUnicodeCs || n.encodingID == PEMicrosoftUcs4 || n.encodingID == PEMicrosoftSymbolCs)) {
 		return decodeUtf16(value)
 	}
 

--- a/font/opentype/tables/name_test.go
+++ b/font/opentype/tables/name_test.go
@@ -95,6 +95,15 @@ func TestFamilyNames(t *testing.T) {
 	tu.AssertNoErr(t, err)
 	// NameFontFamily
 	tu.Assert(t, names.Name(1) == "Roboto")
+
+	// Windows font
+	f, err = td.Files.ReadFile("collections/msgothic.ttc")
+	tu.AssertNoErr(t, err)
+	fonts, err = ot.NewLoaders(bytes.NewReader(f))
+	tu.AssertNoErr(t, err)
+	names, _, err = ParseName(readTable(t, fonts[0], "name"))
+	tu.AssertNoErr(t, err)
+	tu.Assert(t, names.Name(1) == "MS Gothic")
 }
 
 func TestNames(t *testing.T) {

--- a/fontscan/serialize.go
+++ b/fontscan/serialize.go
@@ -185,7 +185,7 @@ func (ff *fileFootprints) deserializeFrom(src []byte) error {
 	return nil
 }
 
-const cacheFormatVersion = 4
+const cacheFormatVersion = 5
 
 func max(i, j int) int {
 	if i > j {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/go-text/typesetting
 go 1.17
 
 require (
-	github.com/go-text/typesetting-utils v0.0.0-20240317173224-1986cbe96c66
+	github.com/go-text/typesetting-utils v0.0.0-20241103174707-87a29e9e6066
 	golang.org/x/image v0.3.0
 	golang.org/x/text v0.9.0
 )

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,10 @@ github.com/go-text/typesetting-utils v0.0.0-20231211103740-d9332ae51f04 h1:zBx+p
 github.com/go-text/typesetting-utils v0.0.0-20231211103740-d9332ae51f04/go.mod h1:DDxDdQEnB70R8owOx3LVpEFvpMK9eeH1o2r0yZhFI9o=
 github.com/go-text/typesetting-utils v0.0.0-20240317173224-1986cbe96c66 h1:GUrm65PQPlhFSKjLPGOZNPNxLCybjzjYBzjfoBGaDUY=
 github.com/go-text/typesetting-utils v0.0.0-20240317173224-1986cbe96c66/go.mod h1:DDxDdQEnB70R8owOx3LVpEFvpMK9eeH1o2r0yZhFI9o=
+github.com/go-text/typesetting-utils v0.0.0-20240329101916-eee87fb235a3 h1:levTnuLLUmpavLGbJYLJA7fQnKeS7P1eCdAlM+vReXk=
+github.com/go-text/typesetting-utils v0.0.0-20240329101916-eee87fb235a3/go.mod h1:DDxDdQEnB70R8owOx3LVpEFvpMK9eeH1o2r0yZhFI9o=
+github.com/go-text/typesetting-utils v0.0.0-20241103174707-87a29e9e6066 h1:qCuYC+94v2xrb1PoS4NIDe7DGYtLnU2wWiQe9a1B1c0=
+github.com/go-text/typesetting-utils v0.0.0-20241103174707-87a29e9e6066/go.mod h1:DDxDdQEnB70R8owOx3LVpEFvpMK9eeH1o2r0yZhFI9o=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=


### PR DESCRIPTION
Some Windows fonts use UTF-16 encoding for their family names : we were missing some of them when decoding the 'name' table.

This a fix for #172 (and should also fix #171).

I've also updated the fontscan cache version, to ensure the existing footprints will be properly updated.

@akiyosi Could you confirm this fix resolves your initial issue ? Thank you !