### PR TITLE
shaping: (wrapping) make whitespace trim bidi-aware

### DIFF
--- a/shaping/output.go
+++ b/shaping/output.go
@@ -146,6 +146,11 @@ type Output struct {
 	// the output in order to render each run in a multi-font sequence in the
 	// correct font.
 	Face *font.Face
+
+	// VisualIndex is the visual position of this run within its containing line where
+	// 0 indicates the leftmost run and increasing values move to the right. This is
+	// useful for sorting the runs for drawing purposes.
+	VisualIndex int32
 }
 
 // ToFontUnit converts a metrics (typically found in [Glyph] fields)
@@ -188,7 +193,12 @@ func (o *Output) advanceSpaceAware() fixed.Int26_6 {
 	}
 
 	// adjust the last to account for spaces
-	lastG := o.Glyphs[L-1]
+	var lastG Glyph
+	if o.Direction.Progression() == di.FromTopLeft {
+		lastG = o.Glyphs[L-1]
+	} else {
+		lastG = o.Glyphs[0]
+	}
 	if o.Direction.IsVertical() {
 		if lastG.Height == 0 {
 			return o.Advance - lastG.YAdvance

--- a/shaping/output.go
+++ b/shaping/output.go
@@ -184,11 +184,14 @@ func (o *Output) RecomputeAdvance() {
 // advanceSpaceAware adjust the value in [Advance]
 // if a white space character ends the run.
 // Any end letter spacing (on the last glyph) is also removed
+// The paragraphDir is the text direction of the overall paragraph containing o.
+// If the paragraphDir is different then o's Direction, this method has no effect
+// because the trailing space in this run will always be internal to the paragraph.
 //
 // TODO: should we take into account multiple spaces ?
-func (o *Output) advanceSpaceAware() fixed.Int26_6 {
+func (o *Output) advanceSpaceAware(paragraphDir di.Direction) fixed.Int26_6 {
 	L := len(o.Glyphs)
-	if L == 0 {
+	if L == 0 || paragraphDir != o.Direction {
 		return o.Advance
 	}
 

--- a/shaping/output_test.go
+++ b/shaping/output_test.go
@@ -305,3 +305,165 @@ func TestLine_AdjustBaseline(t *testing.T) {
 		}
 	}
 }
+
+func TestAdvanceSpaceAware(t *testing.T) {
+	type testcase struct {
+		name         string
+		paragraphDir di.Direction
+		run          Output
+		expected     fixed.Int26_6
+	}
+	for _, tc := range []testcase{
+		{
+			name:         "matching ltr no whitespace",
+			paragraphDir: di.DirectionLTR,
+			expected:     10,
+			run: Output{
+				Advance: 10,
+				Glyphs: []Glyph{
+					{
+						Width:      10,
+						XAdvance:   10,
+						RuneCount:  1,
+						GlyphCount: 1,
+					},
+				},
+				Direction: di.DirectionLTR,
+				Runes:     Range{Count: 1},
+			},
+		},
+		{
+			name:         "matching ltr with whitespace",
+			expected:     0,
+			paragraphDir: di.DirectionLTR,
+			run: Output{
+				Advance: 10,
+				Glyphs: []Glyph{
+					{
+						Width:      0,
+						XAdvance:   10,
+						RuneCount:  1,
+						GlyphCount: 1,
+					},
+				},
+				Direction: di.DirectionLTR,
+				Runes:     Range{Count: 1},
+			},
+		},
+		{
+			name:         "matching rtl no whitespace",
+			expected:     10,
+			paragraphDir: di.DirectionRTL,
+			run: Output{
+				Advance: 10,
+				Glyphs: []Glyph{
+					{
+						Width:      10,
+						XAdvance:   10,
+						RuneCount:  1,
+						GlyphCount: 1,
+					},
+				},
+				Direction: di.DirectionRTL,
+				Runes:     Range{Count: 1},
+			},
+		},
+		{
+			name:         "matching rtl with whitespace",
+			expected:     0,
+			paragraphDir: di.DirectionRTL,
+			run: Output{
+				Advance: 10,
+				Glyphs: []Glyph{
+					{
+						Width:      0,
+						XAdvance:   10,
+						RuneCount:  1,
+						GlyphCount: 1,
+					},
+				},
+				Direction: di.DirectionRTL,
+				Runes:     Range{Count: 1},
+			},
+		},
+		{
+			name:         "mismatched ltr no whitespace",
+			expected:     10,
+			paragraphDir: di.DirectionLTR,
+			run: Output{
+				Advance: 10,
+				Glyphs: []Glyph{
+					{
+						Width:      10,
+						XAdvance:   10,
+						RuneCount:  1,
+						GlyphCount: 1,
+					},
+				},
+				Direction: di.DirectionRTL,
+				Runes:     Range{Count: 1},
+			},
+		},
+		{
+			name:         "mismatched ltr with whitespace",
+			expected:     10,
+			paragraphDir: di.DirectionLTR,
+			run: Output{
+				Advance: 10,
+				Glyphs: []Glyph{
+					{
+						Width:      0,
+						XAdvance:   10,
+						RuneCount:  1,
+						GlyphCount: 1,
+					},
+				},
+				Direction: di.DirectionRTL,
+				Runes:     Range{Count: 1},
+			},
+		},
+		{
+			name:         "mismatched rtl no whitespace",
+			expected:     10,
+			paragraphDir: di.DirectionRTL,
+			run: Output{
+				Advance: 10,
+				Glyphs: []Glyph{
+					{
+						Width:      10,
+						XAdvance:   10,
+						RuneCount:  1,
+						GlyphCount: 1,
+					},
+				},
+				Direction: di.DirectionLTR,
+				Runes:     Range{Count: 1},
+			},
+		},
+		{
+			name:         "mismatched rtl with whitespace",
+			expected:     10,
+			paragraphDir: di.DirectionRTL,
+			run: Output{
+				Advance: 10,
+				Glyphs: []Glyph{
+					{
+						Width:      0,
+						XAdvance:   10,
+						RuneCount:  1,
+						GlyphCount: 1,
+					},
+				},
+				Direction: di.DirectionLTR,
+				Runes:     Range{Count: 1},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := tc.run.advanceSpaceAware(tc.paragraphDir)
+			if actual != tc.expected {
+				t.Errorf("expected advance %d, got %d", tc.expected, actual)
+			}
+		})
+	}
+}

--- a/shaping/wrapping.go
+++ b/shaping/wrapping.go
@@ -1165,7 +1165,7 @@ func (l *LineWrapper) processBreakOption(option breakOption, config lineConfig) 
 	}
 	isFirstInLine := l.scratch.candidateLen() == 0
 	candidateRun := cutRun(run, l.mapper.mapping, l.lineStartRune, option.breakAtRune, isFirstInLine)
-	candidateLineWidth := (candidateRun.advanceSpaceAware() + l.scratch.candidateAdvance()).Ceil()
+	candidateLineWidth := (candidateRun.advanceSpaceAware(l.config.Direction) + l.scratch.candidateAdvance()).Ceil()
 	if candidateLineWidth > config.maxWidth {
 		// The run doesn't fit on the line.
 		if !l.scratch.hasBest() {

--- a/shaping/wrapping.go
+++ b/shaping/wrapping.go
@@ -898,13 +898,8 @@ func (l *LineWrapper) postProcessLine(finalLine Line, done bool) (WrappedLine, b
 			}
 			// This next block locates the first/last visual glyph on the line and
 			// zeroes its advance if it is whitespace.
-			var finalVisualRun *Output
+			finalVisualRun := &finalLine[goalIdx]
 			var finalVisualGlyph *Glyph
-			if l.config.Direction.Progression() == di.FromTopLeft {
-				finalVisualRun = &finalLine[goalIdx]
-			} else {
-				finalVisualRun = &finalLine[goalIdx]
-			}
 			if L := len(finalVisualRun.Glyphs); L > 0 {
 				if l.config.Direction.Progression() == di.FromTopLeft {
 					finalVisualGlyph = &finalVisualRun.Glyphs[L-1]

--- a/shaping/wrapping.go
+++ b/shaping/wrapping.go
@@ -858,7 +858,7 @@ func swapVisualOrder(subline Line) {
 	}
 }
 
-// computeBidiOrdering resolve the [VisualIndex] of each run.
+// computeBidiOrdering resolves the [VisualIndex] of each run.
 func computeBidiOrdering(dir di.Direction, finalLine Line) {
 	bidiStart := -1
 	for idx, run := range finalLine {

--- a/shaping/wrapping_test.go
+++ b/shaping/wrapping_test.go
@@ -961,6 +961,7 @@ func compareLines(t *testing.T, lineNumber int, expected, actual Line) {
 		}
 		expected.Glyphs = nil
 		actual.Glyphs = nil
+		actual.VisualIndex = expected.VisualIndex
 		if !reflect.DeepEqual(expected, actual) {
 			t.Errorf("line %d: run %d: expected\n%#+v\ngot\n%#+v", lineNumber, i, expected, actual)
 		}
@@ -1532,6 +1533,7 @@ func TestLineWrap(t *testing.T) {
 					// compared the glyphs.
 					expectedRun.Glyphs = nil
 					actualRun.Glyphs = nil
+					actualRun.VisualIndex = expectedRun.VisualIndex
 					if !reflect.DeepEqual(expectedRun, actualRun) {
 						t.Errorf("line %d: expected: %#v, got %#v", runNum, expectedRun, actualRun)
 					}


### PR DESCRIPTION
Our previous implementation of trimming the whitespace off of the end of wrapped lines assumed that the end was always the final logical run, and that the final glyph within that run was visually last. Neither of these assumptions are true in real-world bidi text. The final logical run may be embedded wtihin the center of the visual line of text, and sometimes the final glyph is the first within a run, rather than the last.