### PR TITLE
Add back Windows and macOS to tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.19.x, stable]
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
These were accidentally removed in my Go 1.19 update PR due to copy paste error from go-text/render which only ran on Ubuntu even before my changes there. Sorry.