### PR TITLE
shaping: treat truncator as proper run for bidi and rune counting

### DIFF
--- a/shaping/wrapping.go
+++ b/shaping/wrapping.go
@@ -973,10 +973,10 @@ func (l *LineWrapper) postProcessLine(finalLine Line, done bool) (WrappedLine, b
 // is non-zero, the final line of text returned by successive calls to WrapNextLine
 // may be truncated. The quantity of runes truncated by wrapping the line is
 // returned in [WrappedLine].Truncated. If this is non-zero AND the LineWrapper's
-// [WrapConfig].Truncator is set, the final [Output] of the truncated line will be a copy
-// of the Truncator with its Runes.Count set to the quantity of runes truncated during
-// line wrapping. The sum of all [Output].Runes.Count in the line will the number of runes
-// provided as input to the line wrapping process.
+// [WrapConfig].Truncator is set, the final line will end with an extra [Output].
+// [Output]s before the final [Output] will represent the input runes that are still
+// visible before truncation, and the final [Output] will be a copy of the Truncator
+// with its Runes.Count set to the quantity of runes truncated during line wrapping.
 func (l *LineWrapper) WrapNextLine(maxWidth int) (out WrappedLine, done bool) {
 	// If we've already finished the paragraph, don't do any more work.
 	if !l.more {

--- a/shaping/wrapping.go
+++ b/shaping/wrapping.go
@@ -973,9 +973,10 @@ func (l *LineWrapper) postProcessLine(finalLine Line, done bool) (WrappedLine, b
 // is non-zero, the final line of text returned by successive calls to WrapNextLine
 // may be truncated. The quantity of runes truncated by wrapping the line is
 // returned in [WrappedLine].Truncated. If this is non-zero AND the LineWrapper's
-// [WrapConfig].Truncator is set, the final run of the truncated will be a copy
+// [WrapConfig].Truncator is set, the final [Output] of the truncated line will be a copy
 // of the Truncator with its Runes.Count set to the quantity of runes truncated during
-// line wrapping.
+// line wrapping. The sum of all [Output].Runes.Count in the line will the number of runes
+// provided as input to the line wrapping process.
 func (l *LineWrapper) WrapNextLine(maxWidth int) (out WrappedLine, done bool) {
 	// If we've already finished the paragraph, don't do any more work.
 	if !l.more {

--- a/shaping/wrapping.go
+++ b/shaping/wrapping.go
@@ -422,7 +422,8 @@ type WrapConfig struct {
 	// the text. A value of zero means no limit.
 	TruncateAfterLines int
 	// Truncator, if provided, will be inserted at the end of a truncated line. This
-	// feature is only active if TruncateAfterLines is nonzero.
+	// feature is only active if TruncateAfterLines is nonzero. See the documentation
+	// for [LineWrapper.WrapNextLine] for details about how this works.
 	Truncator Output
 	// TextContinues indicates that the paragraph wrapped by this config is not the
 	// final paragraph in the text. This alters text truncation when filling the
@@ -767,6 +768,10 @@ func (l *LineWrapper) Prepare(config WrapConfig, paragraph []rune, runs RunItera
 // that many lines. The truncated return value is the count of runes truncated from
 // the end of the text. The returned lines are only valid until the next call to
 // [*LineWrapper.WrapParagraph] or [*LineWrapper.Prepare].
+//
+// See [(*LineWrapper).WrapNextLine] for a description of how [WrapConfig]'s truncation
+// features impact the wrapped text output. This method returns the quantity of runes
+// truncated by line wrapping in the [truncated] return value.
 func (l *LineWrapper) WrapParagraph(config WrapConfig, maxWidth int, paragraph []rune, runs RunIterator) (_ []Line, truncated int) {
 	l.scratch.reset()
 	// Check whether we can skip line wrapping altogether for the simple single-run-that-fits case.
@@ -963,6 +968,14 @@ func (l *LineWrapper) postProcessLine(finalLine Line, done bool) (WrappedLine, b
 //
 // The returned line is only valid until the next call to
 // [*LineWrapper.Prepare] or [*LineWrapper.WrapParagraph].
+//
+// If the LineWrapper's [WrapConfig].TruncateAfterLines
+// is non-zero, the final line of text returned by successive calls to WrapNextLine
+// may be truncated. The quantity of runes truncated by wrapping the line is
+// returned in [WrappedLine].Truncated. If this is non-zero AND the LineWrapper's
+// [WrapConfig].Truncator is set, the final run of the truncated will will be a copy
+// of the Truncator with its Runes.Count set to the quantity of runes truncated during
+// line wrapping.
 func (l *LineWrapper) WrapNextLine(maxWidth int) (out WrappedLine, done bool) {
 	// If we've already finished the paragraph, don't do any more work.
 	if !l.more {

--- a/shaping/wrapping.go
+++ b/shaping/wrapping.go
@@ -973,7 +973,7 @@ func (l *LineWrapper) postProcessLine(finalLine Line, done bool) (WrappedLine, b
 // is non-zero, the final line of text returned by successive calls to WrapNextLine
 // may be truncated. The quantity of runes truncated by wrapping the line is
 // returned in [WrappedLine].Truncated. If this is non-zero AND the LineWrapper's
-// [WrapConfig].Truncator is set, the final run of the truncated will will be a copy
+// [WrapConfig].Truncator is set, the final run of the truncated will be a copy
 // of the Truncator with its Runes.Count set to the quantity of runes truncated during
 // line wrapping.
 func (l *LineWrapper) WrapNextLine(maxWidth int) (out WrappedLine, done bool) {

--- a/shaping/wrapping.go
+++ b/shaping/wrapping.go
@@ -939,7 +939,12 @@ func (l *LineWrapper) postProcessLine(finalLine Line, done bool) (WrappedLine, b
 			insertTruncator = truncated > 0 || l.config.TextContinues
 		}
 		if insertTruncator {
-			finalLine = append(finalLine, l.config.Truncator)
+			truncator := l.config.Truncator
+			truncator.Runes.Count = truncated
+			truncator.Runes.Offset = l.lineStartRune
+			finalLine = append(finalLine, truncator)
+			// We've just modified the line, we need to recompute the bidi ordering.
+			computeBidiOrdering(l.config.Direction, finalLine)
 		}
 	}
 

--- a/shaping/wrapping_test.go
+++ b/shaping/wrapping_test.go
@@ -2133,8 +2133,6 @@ func TestWrappingTruncationEdgeCases(t *testing.T) {
 			lastLine := lines[len(lines)-1]
 			lastRun := lastLine[len(lastLine)-1]
 			shouldTruncate := (tc.expectedTruncated > 0 || tc.forceTruncation)
-			// The VisualIndex and rune counts on the truncator will be populated during wrapping, and thus
-			// are not part of the test case expectations.
 			trunc.VisualIndex = lastRun.VisualIndex
 			trunc.Runes = Range{
 				Offset: len(inputRunes) - tc.expectedTruncated,

--- a/shaping/wrapping_test.go
+++ b/shaping/wrapping_test.go
@@ -1814,7 +1814,7 @@ func checkRuneCounts(t *testing.T, source []rune, lines []Line, truncated int) [
 	for lineIdx, line := range lines {
 		lineTotalRunes := 0
 		for runIdx, run := range line {
-			if truncated > 0 && totalRunes == len(source)-truncated && run.Runes.Offset == 0 {
+			if truncated > 0 && totalRunes == len(source)-truncated && run.Runes.Offset == totalRunes {
 				// Skip the truncator run.
 				continue
 			}
@@ -1903,7 +1903,13 @@ func TestWrappingTruncation(t *testing.T) {
 				}
 				lastLine := newLines[len(newLines)-1]
 				lastRun := lastLine[len(lastLine)-1]
-				if !reflect.DeepEqual(lastRun, truncator) {
+				expected := truncator
+				expected.Runes = Range{
+					Offset: len(textInput) - truncated,
+					Count:  truncated,
+				}
+				expected.VisualIndex = lastRun.VisualIndex
+				if !reflect.DeepEqual(lastRun, expected) {
 					t.Errorf("expected truncator as last run")
 				}
 			} else if i >= untruncatedCount {
@@ -1920,12 +1926,8 @@ func TestWrappingTruncation(t *testing.T) {
 					runeCount += run.Runes.Count
 				}
 			}
-			// Remove the runes of the truncator, if any.
-			if truncated > 0 {
-				runeCount -= truncator.Runes.Count
-			}
-			if runeCount+truncated != len(textInput) {
-				t.Errorf("expected %d runes total, got %d output and %d truncated", len(textInput), runeCount, truncated)
+			if runeCount != len(textInput) {
+				t.Errorf("expected %d runes total, got %d output", len(textInput), runeCount)
 			}
 		}
 	}
@@ -2131,6 +2133,13 @@ func TestWrappingTruncationEdgeCases(t *testing.T) {
 			lastLine := lines[len(lines)-1]
 			lastRun := lastLine[len(lastLine)-1]
 			shouldTruncate := (tc.expectedTruncated > 0 || tc.forceTruncation)
+			// The VisualIndex and rune counts on the truncator will be populated during wrapping, and thus
+			// are not part of the test case expectations.
+			trunc.VisualIndex = lastRun.VisualIndex
+			trunc.Runes = Range{
+				Offset: len(inputRunes) - tc.expectedTruncated,
+				Count:  tc.expectedTruncated,
+			}
 			if lastRunIsTruncator := reflect.DeepEqual(lastRun, trunc); lastRunIsTruncator != shouldTruncate {
 				t.Errorf("shouldTruncate = %v, but lastRunIsTruncator = %v", shouldTruncate, lastRunIsTruncator)
 			}


### PR DESCRIPTION
This commit fixes an oversight in our handling of text truncators. They were inserted into the text *after* bidi run reordering had already occurred, which would place them in the wrong visual position sometimes. Additionally, their rune data reflected the runes of the truncator string instead of the runes of text the truncator represents, but it is clearly more desirable for the truncator to stand in for all of the text it replaces.

This commit does change the semantics of a truncator run's Range field in the output text. It will now describe the replaced range of text. This does greatly simplify consuming the shaped text data, as you can see by how it simplified the tests. We don't have to factor out the truncator or do extra math to make sure all runes are accounted for. Instead, the sum of the rune counts of all runs will always equal the full rune count of the input text.