### PR TITLE
two nil guards that we need

### DIFF
--- a/font/opentype/tables/glyphs_glyf_src.go
+++ b/font/opentype/tables/glyphs_glyf_src.go
@@ -39,9 +39,6 @@ type Glyf []Glyph
 // ParseGlyf parses the 'glyf' table.
 // locaOffsets has length numGlyphs + 1, and is returned by ParseLoca
 func ParseGlyf(src []byte, locaOffsets []uint32) (Glyf, error) {
-	if len(src) == 0 {
-		return Glyf{}, nil
-	}
 	out := make(Glyf, len(locaOffsets)-1)
 	var err error
 	for i := range out {

--- a/font/opentype/tables/glyphs_glyf_src.go
+++ b/font/opentype/tables/glyphs_glyf_src.go
@@ -39,6 +39,9 @@ type Glyf []Glyph
 // ParseGlyf parses the 'glyf' table.
 // locaOffsets has length numGlyphs + 1, and is returned by ParseLoca
 func ParseGlyf(src []byte, locaOffsets []uint32) (Glyf, error) {
+	if len(src) == 0 {
+		return Glyf{}, nil
+	}
 	out := make(Glyf, len(locaOffsets)-1)
 	var err error
 	for i := range out {

--- a/shaping/wrapping.go
+++ b/shaping/wrapping.go
@@ -266,6 +266,9 @@ func (option breakOption) isValid(runeToGlyph []int, out Output) bool {
 		// Check if this break is valid.
 		gIdx := runeToGlyph[breakAfter]
 		g2Idx := runeToGlyph[nextRune]
+		if gIdx >= len(out.Glyphs) || g2Idx >= len(out.Glyphs) {
+			return false
+		}
 		cIdx := out.Glyphs[gIdx].ClusterIndex
 		c2Idx := out.Glyphs[g2Idx].ClusterIndex
 		if cIdx == c2Idx {


### PR DESCRIPTION
these allow:

1. nonstandard output wrapping elements with no glyphs. we use this for math rendering, which creates a "dummy" output element for line wrapping purposes.

2. fonts without glyf table (metrics only). we use these for rendering on web platforms that use html canvas measure text but do not require glyf tables, so the font files can be smaller.