### PR TITLE
[shaping] expose ComputeBidiOrdering

### DIFF
--- a/shaping/wrapping_test.go
+++ b/shaping/wrapping_test.go
@@ -3399,7 +3399,7 @@ func TestLineWrapPostProcess(t *testing.T) {
 func TestComputeBidiOrdering(t *testing.T) {
 	type testcase struct {
 		name                string
-		input               []Output
+		input               Line
 		direction           di.Direction
 		expectedVisualOrder []int
 	}
@@ -3486,7 +3486,7 @@ func TestComputeBidiOrdering(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			computeBidiOrdering(tc.direction, tc.input)
+			tc.input.ComputeBidiOrdering(tc.direction)
 			for visualIndex, logicalIndex := range tc.expectedVisualOrder {
 				if tc.input[logicalIndex].VisualIndex != int32(visualIndex) {
 					t.Errorf("line[%d]: expected visual index %v, got %v", logicalIndex, visualIndex, tc.input[logicalIndex].VisualIndex)


### PR DESCRIPTION
This PR expose the logic used to compute visual ordering for mixed LRT/RTL text. 

It could be used to fix go-text/render#23 in the `render` package.

It also includes a very small change so that it could also be used for vertical text (comparing `Progression` instead of `Direction`).