### PR TITLE
[harfbuzz] check advances in test suite (related to #210)

### DIFF
--- a/harfbuzz/harfbuzz_shape_test.go
+++ b/harfbuzz/harfbuzz_shape_test.go
@@ -284,6 +284,17 @@ func (mft testInput) shape(t *testing.T, verify bool) (string, error) {
 		return "", err
 	}
 
+	// check that YAdvance is only used for vertical text
+	// and XAdvance for horizontal text
+	isHorizontal := buffer.Props.Direction.isHorizontal()
+	for _, pos := range buffer.Pos {
+		if isHorizontal {
+			tu.Assert(t, pos.YAdvance == 0)
+		} else {
+			tu.Assert(t, pos.XAdvance == 0)
+		}
+	}
+
 	return buffer.serialize(font, mft.format), nil
 }
 


### PR DESCRIPTION
This PR simply adds a check in the the Harfbuzz test suite, proving that only one advance field is written at at time (see #210).