### PR TITLE
Modify error return to nil in scandir.go (Fixes broken Chinese characters in flatpak)

### DIFF
--- a/fontscan/scandir.go
+++ b/fontscan/scandir.go
@@ -1,6 +1,8 @@
 package fontscan
 
 import (
+	"errors"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -27,7 +29,11 @@ func (dst *footprintScanner) scanDirectory(logger Logger, dir string, visited ma
 		// load the information, following potential symoblic links
 		info, err := os.Stat(path)
 		if err != nil {
-			return err
+			if errors.Is(err, os.ErrNotExist) {
+				logger.Printf("skipping dead link or missing file: %q", path)
+				return nil
+			}
+			return fmt.Errorf("failed to stat %q: %w", path, err)
 		}
 
 		// always ignore files which should never be font files


### PR DESCRIPTION
Change error handling to return nil instead of an error to avoid causing the entire font scan to fail.