### PR TITLE
[shaping] add Advance; deprecate some other fields

### DIFF
--- a/shaping/output.go
+++ b/shaping/output.go
@@ -26,11 +26,19 @@ type Glyph struct {
 	// YBearing is the distance between the dot (with offset applied) and
 	// the top of the glyph content, typically positive
 	YBearing fixed.Int26_6
+	// Advance is the distance between the current dot (without offset applied) and the next dot.
+	// It is typically positive for horizontal text, and negative for vertical text.
+	Advance fixed.Int26_6
+
 	// XAdvance is the distance between the current dot (without offset applied) and the next dot.
 	// It is typically positive for horizontal text, and always zero for vertical text.
+	//
+	// Deprecated: Use Advance instead.
 	XAdvance fixed.Int26_6
 	// YAdvance is the distance between the current dot (without offset applied) and the next dot.
 	// It is typically negative for vertical text, and always zero for horizontal text.
+	//
+	// Deprecated: Use Advance instead.
 	YAdvance fixed.Int26_6
 
 	// Offsets to be applied to the dot before actually drawing
@@ -43,11 +51,17 @@ type Glyph struct {
 	// this glyph cluster. All glyphs sharing the same cluster value
 	// are part of the same cluster and will have identical RuneCount
 	// and GlyphCount fields.
+	//
+	// Deprecated: Use TextIndex() instead.
 	ClusterIndex int
 	// RuneCount is the number of input runes shaped into this output
 	// glyph cluster.
+	//
+	// Deprecated: Use RunesCount() instead.
 	RuneCount int
 	// GlyphCount is the number of glyphs in this output glyph cluster.
+	//
+	// Deprecated: Use GlyphsCount() instead.
 	GlyphCount int
 	GlyphID    font.GID
 	Mask       uint32
@@ -58,6 +72,19 @@ type Glyph struct {
 	// and will trim [startLetterSpacing] at the start of the lines
 	startLetterSpacing, endLetterSpacing fixed.Int26_6
 }
+
+// TextIndex is the lowest rune index of all runes shaped into
+// this glyph cluster. All glyphs sharing the same cluster value
+// are part of the same cluster and will have identical RunesCount
+// and GlyphsCount values.
+func (g Glyph) TextIndex() int { return g.ClusterIndex }
+
+// RuneCount is the number of input runes shaped into this output
+// glyph cluster.
+func (g Glyph) RunesCount() int { return g.RuneCount }
+
+// GlyphsCount is the number of glyphs in this output glyph cluster.
+func (g Glyph) GlyphsCount() int { return g.GlyphCount }
 
 // LeftSideBearing returns the distance from the glyph's X origin to
 // its leftmost edge. This value can be negative if the glyph extends
@@ -70,7 +97,7 @@ func (g Glyph) LeftSideBearing() fixed.Int26_6 {
 // the edge of the glyph's advance. This value can be negative if the glyph's
 // right edge is after the end of its advance.
 func (g Glyph) RightSideBearing() fixed.Int26_6 {
-	return g.XAdvance - g.Width - g.XBearing
+	return g.Advance - g.Width - g.XBearing
 }
 
 // Bounds describes the minor-axis bounds of a line of text. In a LTR or RTL
@@ -169,14 +196,8 @@ func (o *Output) FromFontUnit(v float32) fixed.Int26_6 {
 // and can be used to speed up line wrapping logic.
 func (o *Output) RecomputeAdvance() {
 	advance := fixed.Int26_6(0)
-	if o.Direction.IsVertical() {
-		for _, g := range o.Glyphs {
-			advance += g.YAdvance
-		}
-	} else { // horizontal
-		for _, g := range o.Glyphs {
-			advance += g.XAdvance
-		}
+	for _, g := range o.Glyphs {
+		advance += g.Advance
 	}
 	o.Advance = advance
 }
@@ -204,11 +225,11 @@ func (o *Output) advanceSpaceAware(paragraphDir di.Direction) fixed.Int26_6 {
 	}
 	if o.Direction.IsVertical() {
 		if lastG.Height == 0 {
-			return o.Advance - lastG.YAdvance
+			return o.Advance - lastG.Advance
 		}
 	} else { // horizontal
 		if lastG.Width == 0 {
-			return o.Advance - lastG.XAdvance
+			return o.Advance - lastG.Advance
 		}
 	}
 	return o.Advance - lastG.endLetterSpacing
@@ -228,7 +249,7 @@ func (o *Output) RecalculateAll() {
 	if o.Direction.IsVertical() {
 		for i := range o.Glyphs {
 			g := &o.Glyphs[i]
-			advance += g.YAdvance
+			advance += g.Advance
 			depth := g.XOffset + g.XBearing // start of the glyph
 			if depth < descent {
 				descent = depth
@@ -241,7 +262,7 @@ func (o *Output) RecalculateAll() {
 	} else { // horizontal
 		for i := range o.Glyphs {
 			g := &o.Glyphs[i]
-			advance += g.XAdvance
+			advance += g.Advance
 			height := g.YBearing + g.YOffset
 			if height > ascent {
 				ascent = height
@@ -276,8 +297,7 @@ func (out *Output) sideways() {
 		out.Glyphs[i].XBearing = g.YBearing + g.Height
 		out.Glyphs[i].YBearing = g.Width
 		// switch advance direction
-		out.Glyphs[i].XAdvance = 0
-		out.Glyphs[i].YAdvance = -g.XAdvance // YAdvance is negative
+		out.Glyphs[i].Advance = -g.Advance // Advance for vertical text is negative
 		// apply a rotation around the dot, and position the glyph
 		// below the dot
 		out.Glyphs[i].XOffset = g.YOffset

--- a/shaping/output_test.go
+++ b/shaping/output_test.go
@@ -32,7 +32,15 @@ var (
 	simpleGlyph_ = Glyph{
 		GlyphID:  simpleGID,
 		XAdvance: fixed.I(10),
+		Advance:  fixed.I(10),
+		Width:    fixed.I(10),
+		Height:   -fixed.I(10),
+		YBearing: fixed.I(10),
+	}
+	simpleGlyphVert = Glyph{
+		GlyphID:  simpleGID,
 		YAdvance: -fixed.I(10),
+		Advance:  -fixed.I(10),
 		Width:    fixed.I(10),
 		Height:   -fixed.I(10),
 		YBearing: fixed.I(10),
@@ -40,7 +48,16 @@ var (
 	deepGlyph = Glyph{
 		GlyphID:  deepGID,
 		XAdvance: fixed.I(10),
+		Advance:  fixed.I(10),
+		XOffset:  -fixed.I(5),
+		Width:    fixed.I(10),
+		Height:   -fixed.I(10),
+		YBearing: fixed.I(0),
+	}
+	deepGlyphVert = Glyph{
+		GlyphID:  deepGID,
 		YAdvance: -fixed.I(10),
+		Advance:  -fixed.I(10),
 		XOffset:  -fixed.I(5),
 		Width:    fixed.I(10),
 		Height:   -fixed.I(10),
@@ -49,7 +66,18 @@ var (
 	offsetGlyph = Glyph{
 		GlyphID:  offsetGID,
 		XAdvance: fixed.I(10),
+		Advance:  fixed.I(10),
+		XOffset:  -fixed.I(2),
+		YOffset:  fixed.I(2),
+		Width:    fixed.I(10),
+		Height:   -fixed.I(10),
+		YBearing: fixed.I(10),
+		XBearing: fixed.I(1),
+	}
+	offsetGlyphVert = Glyph{
+		GlyphID:  offsetGID,
 		YAdvance: -fixed.I(10),
+		Advance:  -fixed.I(10),
 		XOffset:  -fixed.I(2),
 		YOffset:  fixed.I(2),
 		Width:    fixed.I(10),
@@ -120,12 +148,12 @@ func TestRecalculate(t *testing.T) {
 		{
 			Name:      "vertical single simple glyph",
 			Direction: di.DirectionTTB,
-			Input:     []Glyph{simpleGlyph_},
+			Input:     []Glyph{simpleGlyphVert},
 			Output: Output{
-				Glyphs:  []Glyph{simpleGlyph_},
-				Advance: simpleGlyph_.YAdvance,
+				Glyphs:  []Glyph{simpleGlyphVert},
+				Advance: simpleGlyphVert.YAdvance,
 				GlyphBounds: Bounds{
-					Ascent:  simpleGlyph_.Width,
+					Ascent:  simpleGlyphVert.Width,
 					Descent: 0,
 				},
 				LineBounds: expectedFontExtents,
@@ -134,13 +162,13 @@ func TestRecalculate(t *testing.T) {
 		{
 			Name:      "vertical glyph below baseline",
 			Direction: di.DirectionTTB,
-			Input:     []Glyph{simpleGlyph_, deepGlyph},
+			Input:     []Glyph{simpleGlyphVert, deepGlyphVert},
 			Output: Output{
-				Glyphs:  []Glyph{simpleGlyph_, deepGlyph},
-				Advance: simpleGlyph_.YAdvance + deepGlyph.YAdvance,
+				Glyphs:  []Glyph{simpleGlyphVert, deepGlyphVert},
+				Advance: simpleGlyphVert.YAdvance + deepGlyphVert.YAdvance,
 				GlyphBounds: Bounds{
-					Ascent:  simpleGlyph_.Width,
-					Descent: deepGlyph.XOffset + deepGlyph.XBearing,
+					Ascent:  simpleGlyphVert.Width,
+					Descent: deepGlyphVert.XOffset + deepGlyphVert.XBearing,
 				},
 				LineBounds: expectedFontExtents,
 			},
@@ -148,13 +176,13 @@ func TestRecalculate(t *testing.T) {
 		{
 			Name:      "vertical single complex glyph",
 			Direction: di.DirectionTTB,
-			Input:     []Glyph{offsetGlyph},
+			Input:     []Glyph{offsetGlyphVert},
 			Output: Output{
-				Glyphs:  []Glyph{offsetGlyph},
-				Advance: offsetGlyph.YAdvance,
+				Glyphs:  []Glyph{offsetGlyphVert},
+				Advance: offsetGlyphVert.YAdvance,
 				GlyphBounds: Bounds{
-					Ascent:  offsetGlyph.Width + offsetGlyph.XOffset + offsetGlyph.XBearing,
-					Descent: offsetGlyph.XOffset + offsetGlyph.XBearing,
+					Ascent:  offsetGlyphVert.Width + offsetGlyphVert.XOffset + offsetGlyphVert.XBearing,
+					Descent: offsetGlyphVert.XOffset + offsetGlyphVert.XBearing,
 				},
 				LineBounds: expectedFontExtents,
 			},
@@ -323,7 +351,7 @@ func TestAdvanceSpaceAware(t *testing.T) {
 				Glyphs: []Glyph{
 					{
 						Width:      10,
-						XAdvance:   10,
+						Advance:    10,
 						RuneCount:  1,
 						GlyphCount: 1,
 					},
@@ -341,7 +369,7 @@ func TestAdvanceSpaceAware(t *testing.T) {
 				Glyphs: []Glyph{
 					{
 						Width:      0,
-						XAdvance:   10,
+						Advance:    10,
 						RuneCount:  1,
 						GlyphCount: 1,
 					},
@@ -359,7 +387,7 @@ func TestAdvanceSpaceAware(t *testing.T) {
 				Glyphs: []Glyph{
 					{
 						Width:      10,
-						XAdvance:   10,
+						Advance:    10,
 						RuneCount:  1,
 						GlyphCount: 1,
 					},
@@ -377,7 +405,7 @@ func TestAdvanceSpaceAware(t *testing.T) {
 				Glyphs: []Glyph{
 					{
 						Width:      0,
-						XAdvance:   10,
+						Advance:    10,
 						RuneCount:  1,
 						GlyphCount: 1,
 					},
@@ -395,7 +423,7 @@ func TestAdvanceSpaceAware(t *testing.T) {
 				Glyphs: []Glyph{
 					{
 						Width:      10,
-						XAdvance:   10,
+						Advance:    10,
 						RuneCount:  1,
 						GlyphCount: 1,
 					},
@@ -413,7 +441,7 @@ func TestAdvanceSpaceAware(t *testing.T) {
 				Glyphs: []Glyph{
 					{
 						Width:      0,
-						XAdvance:   10,
+						Advance:    10,
 						RuneCount:  1,
 						GlyphCount: 1,
 					},
@@ -431,7 +459,7 @@ func TestAdvanceSpaceAware(t *testing.T) {
 				Glyphs: []Glyph{
 					{
 						Width:      10,
-						XAdvance:   10,
+						Advance:    10,
 						RuneCount:  1,
 						GlyphCount: 1,
 					},
@@ -449,7 +477,7 @@ func TestAdvanceSpaceAware(t *testing.T) {
 				Glyphs: []Glyph{
 					{
 						Width:      0,
-						XAdvance:   10,
+						Advance:    10,
 						RuneCount:  1,
 						GlyphCount: 1,
 					},

--- a/shaping/shaping.go
+++ b/shaping/shaping.go
@@ -113,6 +113,7 @@ func (t *HarfbuzzShaper) Shape(input Input) Output {
 	t.buf.Shape(font, t.features)
 
 	// Convert the shaped text into an Output.
+	isVertical := input.Direction.IsVertical()
 	glyphs := make([]Glyph, len(t.buf.Info))
 	for i := range glyphs {
 		g := t.buf.Info[i].Glyph
@@ -131,8 +132,13 @@ func (t *HarfbuzzShaper) Shape(input Input) Output {
 		glyphs[i].Height = fixed.I(int(extents.Height)) >> scaleShift
 		glyphs[i].XBearing = fixed.I(int(extents.XBearing)) >> scaleShift
 		glyphs[i].YBearing = fixed.I(int(extents.YBearing)) >> scaleShift
-		glyphs[i].XAdvance = fixed.I(int(t.buf.Pos[i].XAdvance)) >> scaleShift
-		glyphs[i].YAdvance = fixed.I(int(t.buf.Pos[i].YAdvance)) >> scaleShift
+		if isVertical {
+			glyphs[i].YAdvance = fixed.I(int(t.buf.Pos[i].YAdvance)) >> scaleShift
+			glyphs[i].Advance = glyphs[i].YAdvance
+		} else {
+			glyphs[i].XAdvance = fixed.I(int(t.buf.Pos[i].XAdvance)) >> scaleShift
+			glyphs[i].Advance = glyphs[i].XAdvance
+		}
 		glyphs[i].XOffset = fixed.I(int(t.buf.Pos[i].XOffset)) >> scaleShift
 		glyphs[i].YOffset = fixed.I(int(t.buf.Pos[i].YOffset)) >> scaleShift
 	}

--- a/shaping/spacing.go
+++ b/shaping/spacing.go
@@ -35,6 +35,7 @@ func (run *Output) AddWordSpacing(text []rune, additionalSpacing fixed.Int26_6) 
 		// we have a word separator: add space
 		// we do it by enlarging the separator glyph advance
 		// and distributing space around the glyph content
+		run.Glyphs[i].Advance += additionalSpacing
 		if isVertical {
 			run.Glyphs[i].YAdvance += additionalSpacing
 			run.Glyphs[i].YOffset += additionalSpacing / 2
@@ -64,6 +65,7 @@ func (run *Output) AddLetterSpacing(additionalSpacing fixed.Int26_6, isStartRun,
 
 		// start : apply spacing at boundary only if the run is not the first
 		if startGIdx > 0 || !isStartRun {
+			run.Glyphs[startGIdx].Advance += halfSpacing
 			if isVertical {
 				run.Glyphs[startGIdx].YAdvance += halfSpacing
 				run.Glyphs[startGIdx].YOffset += halfSpacing
@@ -77,6 +79,7 @@ func (run *Output) AddLetterSpacing(additionalSpacing fixed.Int26_6, isStartRun,
 		// end : apply spacing at boundary only if the run is not the last
 		isLastCluster := startGIdx+startGlyph.GlyphCount >= len(run.Glyphs)
 		if !isLastCluster || !isEndRun {
+			run.Glyphs[endGIdx].Advance += halfSpacing
 			if isVertical {
 				run.Glyphs[endGIdx].YAdvance += halfSpacing
 			} else {
@@ -99,6 +102,7 @@ func (run *Output) trimStartLetterSpacing() {
 	}
 	firstG := &run.Glyphs[0]
 	halfSpacing := firstG.startLetterSpacing
+	firstG.Advance -= halfSpacing
 	if run.Direction.IsVertical() {
 		firstG.YAdvance -= halfSpacing
 		firstG.YOffset -= halfSpacing

--- a/shaping/wrapping.go
+++ b/shaping/wrapping.go
@@ -956,10 +956,12 @@ func (l *LineWrapper) postProcessLine(finalLine Line, done bool) (WrappedLine, b
 				if finalVisualRun.Direction.IsVertical() {
 					if finalVisualGlyph.Height == 0 {
 						finalVisualGlyph.YAdvance = 0
+						finalVisualGlyph.Advance = 0
 					}
 				} else { // horizontal
 					if finalVisualGlyph.Width == 0 {
 						finalVisualGlyph.XAdvance = 0
+						finalVisualGlyph.Advance = 0
 					}
 				}
 				beforeTrim := finalVisualRun.Advance

--- a/shaping/wrapping_test.go
+++ b/shaping/wrapping_test.go
@@ -1567,8 +1567,7 @@ func complexGlyph(cluster, runes, glyphs int) Glyph {
 	return Glyph{
 		Width:        fixed.I(10),
 		Height:       fixed.I(10),
-		XAdvance:     fixed.I(10),
-		YAdvance:     fixed.I(10),
+		Advance:      fixed.I(10),
 		YBearing:     fixed.I(10),
 		ClusterIndex: cluster,
 		GlyphCount:   glyphs,


### PR DESCRIPTION
This implements the transition path discussed in #210.

I've tried and make the minimal changes so that tests pass. As proposed, this PR 

- adds methods `Glyph.TextIndex() int`, `Glyph.RunesCount() int`, `Glyph.GlyphsCount() int` 
- adds a field `Glyph.Advance`
- deprecates `XAdvance`, `YAdvance`, `ClusterIndex`, `RuneCount`, `GlyphCount` fields
