### PR TITLE
[shaping] adjust default cache size

### DIFF
--- a/shaping/shaping.go
+++ b/shaping/shaping.go
@@ -24,7 +24,7 @@ type HarfbuzzShaper struct {
 // It is safe to adjust the size after using the shaper, though shrinking
 // it may result in many evictions on the next shaping.
 func (h *HarfbuzzShaper) SetFontCacheSize(size int) {
-	h.fonts.maxSize = size
+	h.fonts.maxSizeOffset = size - defaultFontCacheSize
 }
 
 var _ Shaper = (*HarfbuzzShaper)(nil)


### PR DESCRIPTION
This is a fix for #190 : the `HarfbuzzShaper` zero value now has a non empty font cache.
 
@whereswaldon @hajimehoshi  Maybe you have an educated guess for the value of `defaultFontCacheSize` ?