### PR TITLE
fix oneline overflow (copy from pr#226)

### DIFF
--- a/shaping/wrapping.go
+++ b/shaping/wrapping.go
@@ -1,6 +1,7 @@
 package shaping
 
 import (
+	"math"
 	"sort"
 
 	"github.com/go-text/typesetting/di"
@@ -784,6 +785,10 @@ func (l *LineWrapper) Prepare(config WrapConfig, paragraph []rune, runs RunItera
 //
 // See also [WrapParagraphF] which supports a decimal [maxWidth].
 func (l *LineWrapper) WrapParagraph(config WrapConfig, maxWidth int, paragraph []rune, runs RunIterator) (_ []Line, truncated int) {
+	maxFixed := math.MaxInt32 >> 6
+	if maxWidth > maxFixed {
+		maxWidth = maxFixed
+	}
 	return l.WrapParagraphF(config, fixed.I(maxWidth), paragraph, runs)
 }
 


### PR DESCRIPTION
I have discovered this bug when updating go-text/typesetting to v0.3.3 and the gioui/widget.Editor SingleLine=true stopped working and text was displayed vertical one character per line.  I have traced it to widget/text.go line 246-254. 

```go
	maxWidth := gtx.Constraints.Max.X
	if e.SingleLine {
		maxWidth = math.MaxInt
	}
	minWidth := gtx.Constraints.Min.X
	if maxWidth != e.params.MaxWidth {
		e.params.MaxWidth = maxWidth
		e.invalidate()
	}
```

Which caused and overflow in text/gotext.go line 514. 
```go
	return s.wrapper.WrapParagraph(wc, params.MaxWidth, txt, shaping.NewSliceIterator(s.shapeText(params.PxPerEm, params.Locale, txt)))

```

which progressed to shaping/wrapping.go from github.com/go-text/typesetting v 0.3.3, where the overflow occurs.  `fixed.I(maxWidth)`  -> `-64` when `maxWidth` is `math.MaxInt`

```go
func (l *LineWrapper) WrapParagraph(config WrapConfig, maxWidth int, paragraph []rune, runs RunIterator) (_ []Line, truncated int) {
	return l.WrapParagraphF(config, fixed.I(maxWidth), paragraph, runs)
}
```

The error before the fix was applied.

```bash
--- FAIL: TestWrapping_oneLine_overflow_bug (0.00s)
    wrapping_test.go:3614: expected one line, got 2
    wrapping_test.go:3620: expected no line, got 2
```

I have created a safety check for the overflow and created a test to verify