### PR TITLE
[font] expose the flavor

### DIFF
--- a/font/font.go
+++ b/font/font.go
@@ -136,6 +136,10 @@ type FontID struct {
 //
 // All its methods are read-only and a [*Font] object is thus safe for concurrent use.
 type Font struct {
+	// Flavor represents the kind of font, as indicated by the first four bytes of the file.
+	// It is one of [ot.TrueType], [ot.TrueTypeApple], [ot.PostScript1], [ot.OpenType]
+	Flavor Tag
+
 	// Cmap is the 'cmap' table
 	Cmap    Cmap
 	cmapVar UnicodeVariations
@@ -197,6 +201,7 @@ func NewFont(ld *ot.Loader) (*Font, error) {
 		out Font
 		err error
 	)
+	out.Flavor = ld.Type
 
 	// 'cmap' handling depend on os2
 	raw, _ := ld.RawTable(ot.MustNewTag("OS/2"))

--- a/font/font_test.go
+++ b/font/font_test.go
@@ -120,6 +120,7 @@ func TestLoadCFF2(t *testing.T) {
 
 	font, err := NewFont(ld)
 	tu.AssertNoErr(t, err)
+	tu.Assert(t, font.Flavor == ot.OpenType)
 
 	tu.Assert(t, font.cff2 != nil)
 	tu.Assert(t, font.cff2.VarStore.AxisCount() == 1)
@@ -140,6 +141,7 @@ func TestLoadColor(t *testing.T) {
 	ld := readFontFile(t, "color/NotoColorEmoji-Regular.ttf")
 	ft, err := NewFont(ld)
 	tu.AssertNoErr(t, err)
+	tu.Assert(t, ft.Flavor == ot.TrueType)
 	tu.Assert(t, ft.COLR != nil && ft.CPAL != nil)
 
 	ld = readFontFile(t, "color/CoralPixels-Regular.ttf")


### PR DESCRIPTION
We already compute this flag in the lower-level `loader` package: this PR surfaces this information.