### PR TITLE
[shaping] better face selection for mixed RTL/LTR with marks

### DIFF
--- a/shaping/input.go
+++ b/shaping/input.go
@@ -117,7 +117,7 @@ func SplitByFontGlyphs(input Input, availableFaces []*font.Face) []Input {
 // the return value of the [Fontmap.ResolveFace] call.
 // The 'Face' field of 'input' is ignored: only 'availableFaces' is used to select the face.
 func SplitByFace(input Input, availableFaces Fontmap) []Input {
-	return splitByFace(input, availableFaces, nil)
+	return splitByFace(input, availableFaces, nil, true)
 }
 
 // Segmenter holds a state used to split input
@@ -395,22 +395,40 @@ func (seg *Segmenter) splitByVertOrientation() {
 // assume [splitByScript] has been called
 func (seg *Segmenter) splitByFace(faces Fontmap) {
 	withScript, hasScriptSupport := faces.(FontmapScript)
-	for _, input := range seg.input {
+	lastRunWithoutFace := -1
+	for i, input := range seg.input {
 		if hasScriptSupport {
 			withScript.SetScript(input.Script)
 		}
-		seg.output = splitByFace(input, faces, seg.output)
+		isLast := i == len(seg.input)-1
+		L := len(seg.output)
+		seg.output = splitByFace(input, faces, seg.output, isLast)
+		if face := seg.output[L].Face; face != nil {
+			if lastRunWithoutFace != -1 {
+				// apply it back
+				for k := lastRunWithoutFace; k < L; k++ {
+					seg.output[k].Face = face
+				}
+				// reset the marker
+				lastRunWithoutFace = -1
+			}
+		} else {
+			// in this case, only one run has been added by splitByFace
+			if lastRunWithoutFace == -1 {
+				lastRunWithoutFace = L
+			}
+		}
 	}
 }
 
-func splitByFace(input Input, availableFaces Fontmap, buffer []Input) []Input {
+func splitByFace(input Input, availableFaces Fontmap, buffer []Input, isLast bool) []Input {
 	currentInput := input
 	for i := input.RunStart; i < input.RunEnd; i++ {
 		r := input.Text[i]
 		// We can safely ignore characters if we have a face or if there is more text,
 		// but we must force the choice of a face if we still don't have one and we reach
 		// the final rune. Otherwise strings like all-whitespace are never assigned a face.
-		if ignoreFaceChange(r) && (currentInput.Face != nil || i < input.RunEnd-1) {
+		if ignoreFaceChange(r) && (currentInput.Face != nil || !isLast || i < input.RunEnd-1) {
 			// add the rune to the current input
 			continue
 		}

--- a/shaping/input_test.go
+++ b/shaping/input_test.go
@@ -26,6 +26,7 @@ func Test_ignoreFaceChange(t *testing.T) {
 		{'\ufe02', true},
 		{'\U000E0100', true},
 		{'\u06DD', false},
+		{'\u200f', true},
 	}
 	for _, tt := range tests {
 		if got := ignoreFaceChange(tt.args); got != tt.want {
@@ -657,6 +658,23 @@ func TestSplit(t *testing.T) {
 			di.DirectionTTB,
 			[]run{
 				{0, 8, sideways, language.Mongolian, "mn", latinFont},
+			},
+		},
+		{
+			"\u200fabc", // the mark should not trigger a face change, even "across" different directions/scripts
+			di.DirectionLTR,
+			[]run{
+				{0, 1, di.DirectionRTL, language.Common, "fr", latinFont},
+				{1, 4, di.DirectionLTR, language.Latin, "fr", latinFont},
+			},
+		},
+		{
+			"a\u200fabc", // the mark should not trigger a face change, even "across" different directions/scripts
+			di.DirectionLTR,
+			[]run{
+				{0, 1, di.DirectionLTR, language.Latin, "fr", latinFont},
+				{1, 2, di.DirectionRTL, language.Common, "fr", latinFont},
+				{2, 5, di.DirectionLTR, language.Latin, "fr", latinFont},
 			},
 		},
 	} {


### PR DESCRIPTION
When shaping the string `\u200fabc`, out segmentation process produces two runs (`Input`) with correct direction and script, but with _different_ fonts. This is suboptimal : we should not change font for runes such as  \u200f (a RTL mark).

This issue is that our font selection function only works one `Input` at a time, whereas a "cross" run analysis is required here.

This PR aims at fixing this issue, by back propagating the selected font to previous `Input`s.

This is a minor change which should not impact the majority of use cases.