### PR TITLE
[font] Support for EBDT format 1

### DIFF
--- a/font/bitmaps.go
+++ b/font/bitmaps.go
@@ -432,7 +432,7 @@ func parseBitmapDataMetrics(imageData []byte, start, end tables.Offset32, imageF
 	case 6, 7, 8, 9:
 		return bitmapImage{}, fmt.Errorf("valid but currently not implemented bitmap image format: %d", imageFormat)
 	case 1, 2:
-		data, _, err := tables.ParseBitmapData1or2(imageData)
+		data, _, err := tables.ParseBitmapData1Or2(imageData)
 		return bitmapImage{metrics: data.SmallGlyphMetrics, image: data.Image}, err
 	case 17:
 		data, _, err := tables.ParseBitmapData17(imageData)

--- a/font/bitmaps.go
+++ b/font/bitmaps.go
@@ -429,10 +429,10 @@ func parseBitmapDataMetrics(imageData []byte, start, end tables.Offset32, imageF
 	}
 	imageData = imageData[start:end]
 	switch imageFormat {
-	case 1, 6, 7, 8, 9:
+	case 6, 7, 8, 9:
 		return bitmapImage{}, fmt.Errorf("valid but currently not implemented bitmap image format: %d", imageFormat)
-	case 2:
-		data, _, err := tables.ParseBitmapData2(imageData)
+	case 1, 2:
+		data, _, err := tables.ParseBitmapData1or2(imageData)
 		return bitmapImage{metrics: data.SmallGlyphMetrics, image: data.Image}, err
 	case 17:
 		data, _, err := tables.ParseBitmapData17(imageData)

--- a/font/bitmaps_test.go
+++ b/font/bitmaps_test.go
@@ -3,6 +3,7 @@
 package font
 
 import (
+	"bytes"
 	"testing"
 
 	td "github.com/go-text/typesetting-utils/opentype"
@@ -49,4 +50,16 @@ func TestEBLC(t *testing.T) {
 		_, err = newBitmap(eblc, ebdt)
 		tu.AssertNoErr(t, err)
 	}
+}
+
+func TestEBDTFormat1(t *testing.T) {
+	file, err := td.Files.ReadFile("bitmap/simsun.ttc")
+	tu.AssertNoErr(t, err)
+
+	faces, err := ParseTTC(bytes.NewReader(file))
+	tu.AssertNoErr(t, err)
+	tu.Assert(t, len(faces) == 2)
+	sizes := faces[0].BitmapSizes()
+	tu.Assert(t, len(sizes) == 6)
+	tu.Assert(t, sizes[0].XPpem == 12 && sizes[5].XPpem == 17)
 }

--- a/font/opentype/tables/glyphs_bitmap_gen.go
+++ b/font/opentype/tables/glyphs_bitmap_gen.go
@@ -119,11 +119,11 @@ func ParseBitmapData19(src []byte) (BitmapData19, int, error) {
 	return item, n, nil
 }
 
-func ParseBitmapData2(src []byte) (BitmapData2, int, error) {
-	var item BitmapData2
+func ParseBitmapData1or2(src []byte) (BitmapData1or2, int, error) {
+	var item BitmapData1or2
 	n := 0
 	if L := len(src); L < 5 {
-		return item, 0, fmt.Errorf("reading BitmapData2: "+"EOF: expected length: 5, got %d", L)
+		return item, 0, fmt.Errorf("reading BitmapData1or2: "+"EOF: expected length: 5, got %d", L)
 	}
 	item.SmallGlyphMetrics.mustParse(src[0:])
 	n += 5

--- a/font/opentype/tables/glyphs_bitmap_gen.go
+++ b/font/opentype/tables/glyphs_bitmap_gen.go
@@ -119,8 +119,8 @@ func ParseBitmapData19(src []byte) (BitmapData19, int, error) {
 	return item, n, nil
 }
 
-func ParseBitmapData1or2(src []byte) (BitmapData1or2, int, error) {
-	var item BitmapData1or2
+func ParseBitmapData1Or2(src []byte) (BitmapData1Or2, int, error) {
+	var item BitmapData1Or2
 	n := 0
 	if L := len(src); L < 5 {
 		return item, 0, fmt.Errorf("reading BitmapData1or2: "+"EOF: expected length: 5, got %d", L)

--- a/font/opentype/tables/glyphs_bitmap_src.go
+++ b/font/opentype/tables/glyphs_bitmap_src.go
@@ -163,7 +163,7 @@ type BigGlyphMetrics struct {
 
 // Format 1: small metrics, byte-aligned data
 // Format 2: small metrics, bit-aligned data
-type BitmapData1or2 struct {
+type BitmapData1Or2 struct {
 	SmallGlyphMetrics
 	Image []byte `arrayCount:"ToEnd"`
 }

--- a/font/opentype/tables/glyphs_bitmap_src.go
+++ b/font/opentype/tables/glyphs_bitmap_src.go
@@ -161,8 +161,9 @@ type BigGlyphMetrics struct {
 	vertAdvance  uint8 // Vertical advance width in pixels.
 }
 
+// Format 1: small metrics, byte-aligned data
 // Format 2: small metrics, bit-aligned data
-type BitmapData2 struct {
+type BitmapData1or2 struct {
 	SmallGlyphMetrics
 	Image []byte `arrayCount:"ToEnd"`
 }

--- a/font/renderer.go
+++ b/font/renderer.go
@@ -98,6 +98,9 @@ const (
 	JPG
 	// The [GlyphBitmap.Data] slice stores a TIFF encoded image
 	TIFF
+	// BlackAndWhiteBitAligned is the same as [BlackAndWhite], but
+	// each row is padded to a byte boundary.
+	BlackAndWhiteByteAligned
 )
 
 // BitmapSize expose the size of bitmap glyphs.
@@ -155,6 +158,13 @@ func (bt bitmap) glyphData(gid gID, xPpem, yPpem uint16) (GlyphBitmap, error) {
 	switch subtable.imageFormat {
 	case 17, 18, 19: // PNG
 		out.Format = PNG
+	case 1: // See https://learn.microsoft.com/en-us/typography/opentype/spec/ebdt#format-1-small-metrics-byte-aligned-data
+		out.Format = BlackAndWhiteByteAligned
+		// ensure data length
+		rowL := (out.Width + 7) / 8 // ceil
+		if exp := rowL * out.Height; len(out.Data) < exp {
+			return GlyphBitmap{}, fmt.Errorf("EOF in glyph bitmap: expected %d, got %d", exp, len(out.Data))
+		}
 	case 2, 5:
 		out.Format = BlackAndWhite
 		// ensure data length

--- a/font/renderer_test.go
+++ b/font/renderer_test.go
@@ -565,6 +565,21 @@ func TestEblcGlyph(t *testing.T) {
 	}
 }
 
+func TestEBDTFormat1Glyph(t *testing.T) {
+	file, err := td.Files.ReadFile("bitmap/simsun.ttc")
+	tu.AssertNoErr(t, err)
+
+	faces, err := ParseTTC(bytes.NewReader(file))
+	tu.AssertNoErr(t, err)
+	font := faces[0]
+	font.SetPpem(12, 12)
+
+	for gid := GID(100); gid < 500; gid++ {
+		glyph, ok := font.GlyphData(gid).(GlyphBitmap)
+		tu.Assert(t, ok && glyph.Format == BlackAndWhiteByteAligned)
+	}
+}
+
 func TestAppleBitmapGlyph(t *testing.T) {
 	filename := "collections/Gacha_9.dfont"
 	f, err := td.Files.ReadFile(filename)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/go-text/typesetting
 go 1.19
 
 require (
-	github.com/go-text/typesetting-utils v0.0.0-20260223113751-2d88ac90dae3
+	github.com/go-text/typesetting-utils v0.0.0-20260327125527-fbf04b32d9ad
 	golang.org/x/image v0.23.0
 	golang.org/x/text v0.21.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/go-text/typesetting-utils v0.0.0-20260223113751-2d88ac90dae3 h1:drBZzMgdYPbmyXqOto4YhhJGrFIQCX94FpR4MzTCsos=
-github.com/go-text/typesetting-utils v0.0.0-20260223113751-2d88ac90dae3/go.mod h1:3/62I4La/HBRX9TcTpBj4eipLiwzf+vhI+7whTc9V7o=
+github.com/go-text/typesetting-utils v0.0.0-20260327125527-fbf04b32d9ad h1:J6fi06yzug4KkyQo0hK7UZVFBIlCh7iaG38sGq7THaY=
+github.com/go-text/typesetting-utils v0.0.0-20260327125527-fbf04b32d9ad/go.mod h1:3/62I4La/HBRX9TcTpBj4eipLiwzf+vhI+7whTc9V7o=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=


### PR DESCRIPTION
This PR adds support for bitmap black and white glyphs with Format1.

Since the rendering logic should be slightly different than other black and white format already supported, I have added a new format `BlackAndWhiteByteAligned`.

Closes #244 