### PR TITLE
Don't ignore face change for whitespace

### DIFF
--- a/shaping/input.go
+++ b/shaping/input.go
@@ -434,11 +434,22 @@ func splitByFace(input Input, availableFaces Fontmap, buffer []Input, isLast boo
 				// add the rune to the current input
 				continue
 			}
-			if currentInput.Face != nil && isSpace {
-				// We must check if the current face contains an ASCII space.
-				// P.e. NotoSansSymbols-Regular-Subsetted.ttf (on Android) doesn't.
-				if _, ok := currentInput.Face.NominalGlyph(rune(' ')); ok {
-					continue
+			if isSpace {
+				if currentInput.Face == nil {
+					for j := i + 1; j < input.RunEnd; j++ {
+						ignore, isSpace := ignoreFaceChange(input.Text[j])
+						if !ignore && !isSpace {
+							currentInput.Face = availableFaces.ResolveFace(input.Text[j])
+							break
+						}
+					}
+				}
+				if currentInput.Face != nil {
+					// We must check if the current face contains an ASCII space.
+					// P.e. NotoSansSymbols-Regular-Subsetted.ttf (on Android) doesn't.
+					if _, ok := currentInput.Face.NominalGlyph(rune(' ')); ok {
+						continue
+					}
 				}
 			}
 		}

--- a/shaping/input.go
+++ b/shaping/input.go
@@ -428,9 +428,16 @@ func splitByFace(input Input, availableFaces Fontmap, buffer []Input, isLast boo
 		// We can safely ignore characters if we have a face or if there is more text,
 		// but we must force the choice of a face if we still don't have one and we reach
 		// the final rune. Otherwise strings like all-whitespace are never assigned a face.
-		if ignoreFaceChange(r) && (currentInput.Face != nil || !isLast || i < input.RunEnd-1) {
-			// add the rune to the current input
-			continue
+		if currentInput.Face != nil || !isLast || i < input.RunEnd-1 {
+			if ignoreFaceChange(r) {
+				// add the rune to the current input
+				continue
+			}
+			if currentInput.Face != nil && isSpace(r) {
+				if _, ok := currentInput.Face.NominalGlyph(rune(' ')); ok {
+					continue
+				}
+			}
 		}
 
 		// select the first font supporting r
@@ -471,12 +478,6 @@ func splitByFace(input Input, availableFaces Fontmap, buffer []Input, isLast boo
 // ignoreFaceChange returns `true` is the given rune should not trigger
 // a change of font.
 //
-// We don't want space characters to affect font selection; in general,
-// it's always wrong to select a font just to render a space.
-// We assume that all fonts have the ASCII space, and for other space
-// characters if they don't, HarfBuzz will compatibility-decompose them
-// to ASCII space...
-//
 // We don't want to change fonts for line or paragraph separators.
 //
 // Finaly, we also don't change fonts for what Harfbuzz consider
@@ -494,6 +495,18 @@ func ignoreFaceChange(r rune) bool {
 		g == ucd.Zl || // line separator
 		g == ucd.Zp || // paragraph separator
 		harfbuzz.IsDefaultIgnorable(r)
+}
+
+// isSpace returns `true` if the given rune is a space character.
+//
+// We don't want space characters to affect font selection; in general,
+// it's always wrong to select a font just to render a space.
+// We can check if a font has the ASCII space, and for other space
+// characters if they don't, HarfBuzz will compatibility-decompose them
+// to ASCII space...
+func isSpace(r rune) bool {
+	g := ucd.LookupGeneralCategory(r)
+	return g == ucd.Zs && r != '\u1680'
 }
 
 // enforceLang makes sure the returned language is compatible with

--- a/shaping/input.go
+++ b/shaping/input.go
@@ -505,7 +505,7 @@ func ignoreFaceChange(r rune) (ignore, isSpace bool) {
 			g == ucd.Zl || // line separator
 			g == ucd.Zp || // paragraph separator
 			harfbuzz.IsDefaultIgnorable(r),
-		g == ucd.Zs && r != '\u1680'
+		g == ucd.Zs && r != '\u1680' // space separator != OGHAM SPACE MARK
 }
 
 // enforceLang makes sure the returned language is compatible with

--- a/shaping/input.go
+++ b/shaping/input.go
@@ -493,7 +493,6 @@ func ignoreFaceChange(r rune) bool {
 		g == ucd.Cs || // surrogate
 		g == ucd.Zl || // line separator
 		g == ucd.Zp || // paragraph separator
-		(g == ucd.Zs && r != '\u1680') || // space separator != OGHAM SPACE MARK
 		harfbuzz.IsDefaultIgnorable(r)
 }
 

--- a/shaping/input.go
+++ b/shaping/input.go
@@ -429,11 +429,14 @@ func splitByFace(input Input, availableFaces Fontmap, buffer []Input, isLast boo
 		// but we must force the choice of a face if we still don't have one and we reach
 		// the final rune. Otherwise strings like all-whitespace are never assigned a face.
 		if currentInput.Face != nil || !isLast || i < input.RunEnd-1 {
-			if ignoreFaceChange(r) {
+			ignore, isSpace := ignoreFaceChange(r)
+			if ignore {
 				// add the rune to the current input
 				continue
 			}
-			if currentInput.Face != nil && isSpace(r) {
+			if currentInput.Face != nil && isSpace {
+				// We must check if the current face contains an ASCII space.
+				// P.e. NotoSansSymbols-Regular-Subsetted.ttf (on Android) doesn't.
 				if _, ok := currentInput.Face.NominalGlyph(rune(' ')); ok {
 					continue
 				}
@@ -476,7 +479,14 @@ func splitByFace(input Input, availableFaces Fontmap, buffer []Input, isLast boo
 }
 
 // ignoreFaceChange returns `true` is the given rune should not trigger
-// a change of font.
+// a change of font and a second bool that indicates if the rune is a space.
+//
+// We don't want space characters to affect font selection; in general,
+// it's always wrong to select a font just to render a space.
+// We assume that most fonts have the ASCII space, and for other space
+// characters if they don't, HarfBuzz will compatibility-decompose them
+// to ASCII space... We return isSpace because we want to be able to
+// force a space to be rendered with a different font if necessary.
 //
 // We don't want to change fonts for line or paragraph separators.
 //
@@ -488,25 +498,14 @@ func splitByFace(input Input, availableFaces Fontmap, buffer []Input, isLast boo
 // https://bugzilla.gnome.org/show_bug.cgi?id=701652
 // https://bugzilla.gnome.org/show_bug.cgi?id=781123
 // for more details.
-func ignoreFaceChange(r rune) bool {
+func ignoreFaceChange(r rune) (ignore, isSpace bool) {
 	g := ucd.LookupGeneralCategory(r)
 	return g == ucd.Cc || // control
-		g == ucd.Cs || // surrogate
-		g == ucd.Zl || // line separator
-		g == ucd.Zp || // paragraph separator
-		harfbuzz.IsDefaultIgnorable(r)
-}
-
-// isSpace returns `true` if the given rune is a space character.
-//
-// We don't want space characters to affect font selection; in general,
-// it's always wrong to select a font just to render a space.
-// We can check if a font has the ASCII space, and for other space
-// characters if they don't, HarfBuzz will compatibility-decompose them
-// to ASCII space...
-func isSpace(r rune) bool {
-	g := ucd.LookupGeneralCategory(r)
-	return g == ucd.Zs && r != '\u1680'
+			g == ucd.Cs || // surrogate
+			g == ucd.Zl || // line separator
+			g == ucd.Zp || // paragraph separator
+			harfbuzz.IsDefaultIgnorable(r),
+		g == ucd.Zs && r != '\u1680'
 }
 
 // enforceLang makes sure the returned language is compatible with

--- a/shaping/input_test.go
+++ b/shaping/input_test.go
@@ -17,7 +17,7 @@ func Test_ignoreFaceChange(t *testing.T) {
 		args rune
 		want bool
 	}{
-		{' ', true},
+		{' ', false},
 		{'a', false},
 		{'\n', true},
 		{'\r', true},
@@ -139,8 +139,13 @@ func TestSplitByFontGlyphs(t *testing.T) {
 				},
 				{
 					Text:     []rune("aaa AAA "),
-					RunStart: 4, RunEnd: 8,
+					RunStart: 4, RunEnd: 7,
 					Face: upperFont,
+				},
+				{
+					Text:     []rune("aaa AAA "),
+					RunStart: 7, RunEnd: 8,
+					Face: lowerFont,
 				},
 			},
 		},
@@ -222,7 +227,12 @@ func TestSplitByFontGlyphs(t *testing.T) {
 			[]Input{
 				{
 					Text:     []rune(" غير الأحلام"),
-					RunStart: 0, RunEnd: len([]rune(" غير الأحلام")),
+					RunStart: 0, RunEnd: 1,
+					Face: latinFont,
+				},
+				{
+					Text:     []rune(" غير الأحلام"),
+					RunStart: 1, RunEnd: len([]rune(" غير الأحلام")),
 					Face: arabicFont,
 				},
 			},
@@ -256,7 +266,12 @@ func TestSplitByFontGlyphs(t *testing.T) {
 			[]Input{
 				{
 					Text:     []rune(" غير الأحلام "),
-					RunStart: 0, RunEnd: len([]rune(" غير الأحلام ")),
+					RunStart: 0, RunEnd: 1,
+					Face: latinFont,
+				},
+				{
+					Text:     []rune(" غير الأحلام "),
+					RunStart: 1, RunEnd: len([]rune(" غير الأحلام ")),
 					Face: arabicFont,
 				},
 			},
@@ -623,11 +638,13 @@ func TestSplit(t *testing.T) {
 				{10, 16, di.DirectionLTR, language.Latin, "fr", latinFont},
 				{16, 23, di.DirectionLTR, language.Cyrillic, "ru", latinFont},
 				{23, 26, di.DirectionLTR, language.Latin, "fr", latinFont},
-				{26, 31, di.DirectionRTL, language.Arabic, "ar", arabicFont},
+				{26, 27, di.DirectionRTL, language.Arabic, "ar", latinFont},
+				{27, 31, di.DirectionRTL, language.Arabic, "ar", arabicFont},
 				{31, 37, di.DirectionLTR, language.Latin, "fr", latinFont},
 				{37, 44, di.DirectionLTR, language.Cyrillic, "ru", latinFont},
 				{44, 48, di.DirectionLTR, language.Latin, "fr", latinFont},
-				{48, 60, di.DirectionRTL, language.Arabic, "ar", arabicFont},
+				{48, 49, di.DirectionRTL, language.Arabic, "ar", latinFont},
+				{49, 60, di.DirectionRTL, language.Arabic, "ar", arabicFont},
 			},
 		},
 		// vertical text

--- a/shaping/input_test.go
+++ b/shaping/input_test.go
@@ -14,23 +14,25 @@ import (
 
 func Test_ignoreFaceChange(t *testing.T) {
 	tests := []struct {
-		args rune
-		want bool
+		args        rune
+		wantIgnore  bool
+		wantIsSpace bool
 	}{
-		{' ', false},
-		{'a', false},
-		{'\n', true},
-		{'\r', true},
-		{'\f', true},
-		{'\ufe01', true},
-		{'\ufe02', true},
-		{'\U000E0100', true},
-		{'\u06DD', false},
-		{'\u200f', true},
+		{' ', false, true},
+		{'\u00a0', false, true},
+		{'a', false, false},
+		{'\n', true, false},
+		{'\r', true, false},
+		{'\f', true, false},
+		{'\ufe01', true, false},
+		{'\ufe02', true, false},
+		{'\U000E0100', true, false},
+		{'\u06DD', false, false},
+		{'\u200f', true, false},
 	}
 	for _, tt := range tests {
-		if got := ignoreFaceChange(tt.args); got != tt.want {
-			t.Errorf("ignoreFaceChange() = %v, want %v", got, tt.want)
+		if ignore, isSpace := ignoreFaceChange(tt.args); ignore != tt.wantIgnore || isSpace != tt.wantIsSpace {
+			t.Errorf("ignoreFaceChange(U+%x) = %v, %v, want %v, %v", tt.args, ignore, isSpace, tt.wantIgnore, tt.wantIsSpace)
 		}
 	}
 }

--- a/shaping/input_test.go
+++ b/shaping/input_test.go
@@ -229,12 +229,7 @@ func TestSplitByFontGlyphs(t *testing.T) {
 			[]Input{
 				{
 					Text:     []rune(" غير الأحلام"),
-					RunStart: 0, RunEnd: 1,
-					Face: latinFont,
-				},
-				{
-					Text:     []rune(" غير الأحلام"),
-					RunStart: 1, RunEnd: len([]rune(" غير الأحلام")),
+					RunStart: 0, RunEnd: len([]rune(" غير الأحلام")),
 					Face: arabicFont,
 				},
 			},
@@ -268,12 +263,7 @@ func TestSplitByFontGlyphs(t *testing.T) {
 			[]Input{
 				{
 					Text:     []rune(" غير الأحلام "),
-					RunStart: 0, RunEnd: 1,
-					Face: latinFont,
-				},
-				{
-					Text:     []rune(" غير الأحلام "),
-					RunStart: 1, RunEnd: len([]rune(" غير الأحلام ")),
+					RunStart: 0, RunEnd: len([]rune(" غير الأحلام ")),
 					Face: arabicFont,
 				},
 			},
@@ -640,13 +630,11 @@ func TestSplit(t *testing.T) {
 				{10, 16, di.DirectionLTR, language.Latin, "fr", latinFont},
 				{16, 23, di.DirectionLTR, language.Cyrillic, "ru", latinFont},
 				{23, 26, di.DirectionLTR, language.Latin, "fr", latinFont},
-				{26, 27, di.DirectionRTL, language.Arabic, "ar", latinFont},
-				{27, 31, di.DirectionRTL, language.Arabic, "ar", arabicFont},
+				{26, 31, di.DirectionRTL, language.Arabic, "ar", arabicFont},
 				{31, 37, di.DirectionLTR, language.Latin, "fr", latinFont},
 				{37, 44, di.DirectionLTR, language.Cyrillic, "ru", latinFont},
 				{44, 48, di.DirectionLTR, language.Latin, "fr", latinFont},
-				{48, 49, di.DirectionRTL, language.Arabic, "ar", latinFont},
-				{49, 60, di.DirectionRTL, language.Arabic, "ar", arabicFont},
+				{48, 60, di.DirectionRTL, language.Arabic, "ar", arabicFont},
 			},
 		},
 		// vertical text


### PR DESCRIPTION
The assumption "that all fonts have the ASCII space" doesn't hold for Android. P.e. the font `/system/fonts/NotoSansSymbols-Regular-Subsetted.ttf` on my Android device (OnePlus Nord 2 5G), which is used to display "✘", doesn't contain a space character/glyph.

This fixes <https://github.com/fyne-io/fyne/issues/6216>.