### PR TITLE
[shaping] do not use .notdef for non supported spaces

### DIFF
--- a/font/renderer_test.go
+++ b/font/renderer_test.go
@@ -610,7 +610,7 @@ func TestAppleBitmapGlyph(t *testing.T) {
 
 func TestMixedGlyphs(t *testing.T) {
 	for _, filename := range tu.Filenames(t, "common") {
-		if strings.HasPrefix(filename, "common/SourceSans") {
+		if strings.HasPrefix(filename, "common/SourceSans") || strings.HasSuffix(filename, "Subsetted.ttf") {
 			continue
 		}
 		font := loadFont(t, filename)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/go-text/typesetting
 go 1.19
 
 require (
-	github.com/go-text/typesetting-utils v0.0.0-20260327125527-fbf04b32d9ad
+	github.com/go-text/typesetting-utils v0.0.0-20260419141703-4ffe8874dabc
 	golang.org/x/image v0.23.0
 	golang.org/x/text v0.21.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/go-text/typesetting-utils v0.0.0-20260327125527-fbf04b32d9ad h1:J6fi06yzug4KkyQo0hK7UZVFBIlCh7iaG38sGq7THaY=
 github.com/go-text/typesetting-utils v0.0.0-20260327125527-fbf04b32d9ad/go.mod h1:3/62I4La/HBRX9TcTpBj4eipLiwzf+vhI+7whTc9V7o=
+github.com/go-text/typesetting-utils v0.0.0-20260419141703-4ffe8874dabc h1:8FGo2It5K75XkavhTiCKExUfVaVDS1feBnLCru5qeoY=
+github.com/go-text/typesetting-utils v0.0.0-20260419141703-4ffe8874dabc/go.mod h1:3/62I4La/HBRX9TcTpBj4eipLiwzf+vhI+7whTc9V7o=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/shaping/shaping.go
+++ b/shaping/shaping.go
@@ -4,7 +4,9 @@ package shaping
 
 import (
 	"github.com/go-text/typesetting/di"
+	ft "github.com/go-text/typesetting/font"
 	"github.com/go-text/typesetting/harfbuzz"
+	ucd "github.com/go-text/typesetting/internal/unicodedata"
 	"golang.org/x/image/math/fixed"
 )
 
@@ -166,6 +168,9 @@ func (t *HarfbuzzShaper) Shape(input Input) Output {
 		Gap:     fixed.I(int(fontExtents.LineGap)) >> scaleShift,
 	}
 	out.RecalculateAll()
+
+	replaceNotSupportedSpaces(input.Text, out.Glyphs)
+
 	return out
 }
 
@@ -207,5 +212,23 @@ func countClusters(glyphs []Glyph, textLen int, dir di.Progression) {
 		}
 		glyphs[i].GlyphCount = glyphsInCluster
 		glyphs[i].RuneCount = runesInCluster
+	}
+}
+
+// special handling of non supported white space :
+// our face selection process assumes all fonts contains the ASCII space,
+// but it turns out to be sometimes incorrect, for instance for the
+// NotoSansSymbols-Regular-Subsetted.ttf (found on Android)
+func replaceNotSupportedSpaces(text []rune, glyphs []Glyph) {
+	for i, g := range glyphs {
+		const NotFound ft.GID = 0 // this is the default value used by Harfbuzz
+		if !(g.GlyphID == NotFound && g.GlyphsCount() == 1 && g.RunesCount() == 1) {
+			continue
+		}
+		// only replace glyph corresponding to a space
+		if r := text[g.TextIndex()]; ucd.LookupGeneralCategory(r) == ucd.Zs {
+			glyphs[i].GlyphID = ft.EmptyGlyph
+			glyphs[i].Width, glyphs[i].Height = 0, 0
+		}
 	}
 }

--- a/shaping/shaping_test.go
+++ b/shaping/shaping_test.go
@@ -725,3 +725,25 @@ func TestShapingLanguage(t *testing.T) {
 	// without the language information, regular space are used
 	tu.Assert(t, output.Glyphs[3].GlyphID == regularSpace)
 }
+
+func TestSpaceReplacement(t *testing.T) {
+	b, err := td.Files.ReadFile("common/NotoSansSymbols-Regular-Subsetted.ttf")
+	tu.AssertNoErr(t, err)
+	face, err := font.ParseTTF(bytes.NewReader(b))
+	tu.AssertNoErr(t, err)
+
+	text := []rune("✘  ✘")
+	out := (&HarfbuzzShaper{}).Shape(Input{
+		Text:   text,
+		RunEnd: len(text),
+		Face:   face,
+		Size:   fixed.I(10),
+	})
+	tu.Assert(t, len(out.Glyphs) == 4)
+	tu.Assert(t, out.Glyphs[1].Advance.Round() == 6)
+	tu.Assert(t, out.Glyphs[1].Width.Round() == 0)
+	tu.Assert(t, out.Glyphs[1].GlyphID == font.EmptyGlyph)
+	tu.Assert(t, out.Glyphs[2].Advance.Round() == 6)
+	tu.Assert(t, out.Glyphs[2].Width.Round() == 0)
+	tu.Assert(t, out.Glyphs[2].GlyphID == font.EmptyGlyph)
+}


### PR DESCRIPTION
Almost all fonts in the wild contains a glyph for the ASCII white space, so that out font selection never selects a font just to render a space. This is in particular important to preserve correct line height (changing font could increase the line height, which is not desirable).

However, the very surprising NotoSansSymbols-Regular-Subsetted.ttf found on Android devices does *not* include a space glyph. This is very annoying and actually not so easy to fix (see previous tries at #248 and #255).

I think this PR is a better solution : it doesn't change the face selection, but replace `.notdef` glyphs by a sentinel `font.EmptyGlyph` value. Consumers of go-text are supposed to take this glyph in account for width/advance computation, but not to draw anything (that is actually the behavior of a standard space glyph).

Note that even if a toolkit does not explicitly check for the `font.EmptyGlyph`, the default behavior should be correct since the font will never have any glyph data for this glyph ID.

cc @MaxGyver83 (and @andydotxyz @whereswaldon )
