### PR TITLE
[shaping] fix crash when wrapping part of string including forced break

### DIFF
--- a/shaping/wrapping.go
+++ b/shaping/wrapping.go
@@ -1,7 +1,6 @@
 package shaping
 
 import (
-	"fmt"
 	"math"
 	"sort"
 
@@ -509,7 +508,6 @@ type runMapper struct {
 // current mapping value is already correct.
 func (r *runMapper) mapRun(runIdx int, run Output) {
 	if r.runIdx != runIdx || !r.valid {
-		fmt.Println(run.Runes)
 		r.mapping = mapRunesToClusterIndices3(run.Direction, run.Runes, run.Glyphs, r.mapping)
 		r.runIdx = runIdx
 		r.valid = true

--- a/shaping/wrapping.go
+++ b/shaping/wrapping.go
@@ -1,6 +1,7 @@
 package shaping
 
 import (
+	"fmt"
 	"math"
 	"sort"
 
@@ -508,6 +509,7 @@ type runMapper struct {
 // current mapping value is already correct.
 func (r *runMapper) mapRun(runIdx int, run Output) {
 	if r.runIdx != runIdx || !r.valid {
+		fmt.Println(run.Runes)
 		r.mapping = mapRunesToClusterIndices3(run.Direction, run.Runes, run.Glyphs, r.mapping)
 		r.runIdx = runIdx
 		r.valid = true
@@ -1218,7 +1220,10 @@ func (l *LineWrapper) processBreakOption(option breakOption, config lineConfig) 
 	// Fill candidate line with runs until the run containing the break option.
 	l.fillUntil(l.glyphRuns, option)
 
-	currRunIndex, run, _ := l.glyphRuns.Peek()
+	currRunIndex, run, isValid := l.glyphRuns.Peek()
+	if !isValid {
+		return breakInvalid, Output{}
+	}
 	l.mapper.mapRun(currRunIndex, run)
 	if !option.isValid(l.mapper.mapping, run) {
 		// Reject invalid line break candidate and acquire a new one.

--- a/shaping/wrapping_test.go
+++ b/shaping/wrapping_test.go
@@ -3623,3 +3623,16 @@ func TestWrapping_oneLine_overflow_bug(t *testing.T) {
 	_, done := l.WrapNextLine(maxWidth)
 	tu.Assert(t, done)
 }
+
+func TestWrapForcedBreak(t *testing.T) {
+	f := loadOpentypeFont(t, "../font/testdata/Roboto-Regular.ttf")
+
+	s := []rune("line1\nline2")
+	// bidi segmentation will split the input at the first line
+	input := Input{Text: s, RunEnd: 5, Direction: di.DirectionLTR, Size: fixed.I(10), Face: f}
+	run := (&HarfbuzzShaper{}).Shape(input)
+
+	var l LineWrapper
+	l.Prepare(WrapConfig{BreakPolicy: Never}, []rune(s), NewSliceIterator([]Output{run}))
+	_, _ = l.WrapNextLine(math.MaxInt) // assert there is no crash
+}


### PR DESCRIPTION
We recently changed our Bidi implementation, introducing a subtle difference when handling strings containing line breaks (`\n`). 

The x/text implementation, despite claiming 

> If s contains a paragraph separator it will only process the first paragraph and report the number of bytes
> consumed from s including this separator.

actually segments `line1\nline2` as a single run containing the whole text.

The new Bidi implementation correctly recognizes two paragraphs, and according to the Unicode spec, properly truncates the text input.

This change uncovers a latent bug (see the included test). I'm not 100% sure this PR is the proper fix and would love to have confirmation from @whereswaldon 