### PR TITLE
font/cff: bound INDEX count/offSize to prevent huge allocation

### DIFF
--- a/font/cff/parser.go
+++ b/font/cff/parser.go
@@ -283,22 +283,21 @@ func parseIndexContent(src []byte, header indexStart) ([][]byte, int, error) {
 	oSize := int(header.offSize)
 	// offSize must be 1..4 (CFF spec, 5176 §5). The CFF2 INDEX header parser
 	// (indexStart.mustParse) does not validate it the way the CFF1 path does,
-	// so a malformed font can present offSize 0 — which zeroes offsetArraySize
-	// below and defeats the length check — or a huge 32-bit count. Either lets
-	// make([][]byte, count) allocate gigabytes before the loop errors out.
-	// Reject a bad offSize and bound count by the bytes actually available for
-	// the offset array (each of the count+1 offsets is oSize bytes). int()
-	// widens count to avoid the uint32 wrap in count+1 (0xFFFFFFFF+1 == 0).
+	// so a malformed font can present offSize 0, which would zero the offset
+	// array size below and let the length check pass while
+	// make([][]byte, count) still allocates gigabytes.
 	if oSize < 1 || oSize > 4 {
 		return nil, 0, fmt.Errorf("reading INDEX: invalid offSize %d", oSize)
 	}
-	if int(header.count) > len(src)/oSize {
-		return nil, 0, fmt.Errorf("reading INDEX: count %d exceeds available data (%d bytes)", header.count, len(src))
+	// The offset array holds count+1 offsets of oSize bytes each. Compute in
+	// uint64 so that a 32-bit count near 0xFFFFFFFF cannot wrap, on 64- or
+	// 32-bit platforms alike. Passing this check implies the size fits in an
+	// int (it is <= len(src)) and bounds count, so the make below is safe.
+	size := (uint64(header.count) + 1) * uint64(oSize)
+	if uint64(len(src)) < size {
+		return nil, 0, fmt.Errorf("reading INDEX offsets: EOF: expected length: %d, got %d", size, len(src))
 	}
-	offsetArraySize := (int(header.count) + 1) * oSize
-	if L := len(src); L < offsetArraySize {
-		return nil, 0, fmt.Errorf("reading INDEX offsets: EOF: expected length: %d, got %d", offsetArraySize, L)
-	}
+	offsetArraySize := int(size)
 	out := make([][]byte, header.count)
 	data := src[offsetArraySize:]
 

--- a/font/cff/parser.go
+++ b/font/cff/parser.go
@@ -281,7 +281,21 @@ func parseIndexContent(src []byte, header indexStart) ([][]byte, int, error) {
 		return nil, 0, nil
 	}
 	oSize := int(header.offSize)
-	offsetArraySize := int(header.count+1) * oSize
+	// offSize must be 1..4 (CFF spec, 5176 §5). The CFF2 INDEX header parser
+	// (indexStart.mustParse) does not validate it the way the CFF1 path does,
+	// so a malformed font can present offSize 0 — which zeroes offsetArraySize
+	// below and defeats the length check — or a huge 32-bit count. Either lets
+	// make([][]byte, count) allocate gigabytes before the loop errors out.
+	// Reject a bad offSize and bound count by the bytes actually available for
+	// the offset array (each of the count+1 offsets is oSize bytes). int()
+	// widens count to avoid the uint32 wrap in count+1 (0xFFFFFFFF+1 == 0).
+	if oSize < 1 || oSize > 4 {
+		return nil, 0, fmt.Errorf("reading INDEX: invalid offSize %d", oSize)
+	}
+	if int(header.count) > len(src)/oSize {
+		return nil, 0, fmt.Errorf("reading INDEX: count %d exceeds available data (%d bytes)", header.count, len(src))
+	}
+	offsetArraySize := (int(header.count) + 1) * oSize
 	if L := len(src); L < offsetArraySize {
 		return nil, 0, fmt.Errorf("reading INDEX offsets: EOF: expected length: %d, got %d", offsetArraySize, L)
 	}

--- a/font/cff/parser_test.go
+++ b/font/cff/parser_test.go
@@ -176,4 +176,14 @@ func TestParseIndexContentBounds(t *testing.T) {
 	// the count+1 uint32 wrap at 0xFFFFFFFF).
 	_, _, err = parseIndexContent(valid, indexStart{count: 0xFFFFFFFF, offSize: 1})
 	tu.Assert(t, err != nil)
+
+	// count exactly len(src)/offSize: the offset array still needs one more
+	// offset than the data holds, so this must be an error rather than a
+	// slice-out-of-range panic on src[offsetArraySize:].
+	_, _, err = parseIndexContent(valid, indexStart{count: 3, offSize: 1})
+	tu.Assert(t, err != nil)
+
+	// offSize > 4 is out of spec and must be rejected.
+	_, _, err = parseIndexContent(valid, indexStart{count: 1, offSize: 5})
+	tu.Assert(t, err != nil)
 }

--- a/font/cff/parser_test.go
+++ b/font/cff/parser_test.go
@@ -155,3 +155,25 @@ func TestIssue122(t *testing.T) {
 	segments, _, _ := out.LoadGlyph(38, nil)
 	tu.Assert(t, len(segments) == 12)
 }
+
+// TestParseIndexContentBounds guards against a malformed INDEX header driving
+// a huge allocation. The CFF2 INDEX header parser does not validate offSize
+// (unlike CFF1), so a font can present offSize 0 — which zeroes the length
+// check — or a 32-bit count far larger than the data; parseIndexContent must
+// reject these instead of make([][]byte, count)-ing gigabytes.
+func TestParseIndexContentBounds(t *testing.T) {
+	// Minimal valid INDEX: count 1, offSize 1, offsets [1,2], one data byte.
+	valid := []byte{0x01, 0x02, 0xAA}
+	out, _, err := parseIndexContent(valid, indexStart{count: 1, offSize: 1})
+	tu.AssertNoErr(t, err)
+	tu.Assert(t, len(out) == 1 && len(out[0]) == 1 && out[0][0] == 0xAA)
+
+	// offSize 0 must be rejected before the allocation.
+	_, _, err = parseIndexContent(valid, indexStart{count: 1 << 20, offSize: 0})
+	tu.Assert(t, err != nil)
+
+	// A count larger than the data can address must be rejected (also covers
+	// the count+1 uint32 wrap at 0xFFFFFFFF).
+	_, _, err = parseIndexContent(valid, indexStart{count: 0xFFFFFFFF, offSize: 1})
+	tu.Assert(t, err != nil)
+}


### PR DESCRIPTION
`parseIndexContent` calls `make([][]byte, count)` with `count` and `offSize` read directly from the font. The CFF2 INDEX header parser (`indexStart.mustParse`) doesn't validate `offSize` the way the CFF1 path (`parseIndexHeader`) does. So a malformed font can present:

- **`offSize == 0`** → `offsetArraySize` becomes 0, defeating the `len(src) < offsetArraySize` length check, or
- **a 32-bit `count` near `0xFFFFFFFF`** → `count+1` wraps to 0 in `uint32`, same effect.

Either drives a multi-gigabyte allocation before the loop errors out. A concrete real-world trigger: macOS `SFIndia.ttc` makes `font.NewFont` allocate ~58 GB, OOM-killing the process (found while shipping a pure-Go terminal that renders arbitrary Unicode).

Fix: reject `offSize` outside 1–4 and bound `count` by the bytes available for the offset array before allocating. Adds `TestParseIndexContentBounds`. Existing `font/cff` tests pass.
