### PR TITLE
font/cff: resolve CFF2 local subrs relative to the Private DICT

### DIFF
--- a/font/cff/cff2.go
+++ b/font/cff/cff2.go
@@ -98,7 +98,13 @@ func ParseCFF2(src []byte) (*CFF2, error) {
 		out.fonts[i].defaultVSIndex = pd.vsindex
 		// if required, parse the local subroutines
 		if pd.subrsOffset != 0 {
-			out.fonts[i].localSubrs, err = parseIndex2(src, int(pd.subrsOffset))
+			// "The local subrs offset is relative to the beginning of the
+			// Private DICT data" (5176.CFF.pdf section 15, and CFF2 section
+			// 10), so it is measured from the Private DICT, not from the start
+			// of the table. The CFF1 parser does this correctly; see
+			// parsePrivateDict.
+			subrsOffset := int(fd.privateDictOffset) + int(pd.subrsOffset)
+			out.fonts[i].localSubrs, err = parseIndex2(src, subrsOffset)
 			if err != nil {
 				return nil, err
 			}
@@ -143,6 +149,9 @@ func ParseCFF2(src []byte) (*CFF2, error) {
 }
 
 func parseIndex2(src []byte, offset int) ([][]byte, error) {
+	if offset < 0 {
+		return nil, fmt.Errorf("reading INDEX: invalid offset %d", offset)
+	}
 	if L := len(src); L < offset+5 {
 		return nil, fmt.Errorf("reading INDEX: EOF: expected length: %d, got %d", offset+5, L)
 	}

--- a/font/cff/parser_test.go
+++ b/font/cff/parser_test.go
@@ -156,6 +156,47 @@ func TestIssue122(t *testing.T) {
 	tu.Assert(t, len(segments) == 12)
 }
 
+// TestCFF2LocalSubrs covers a CFF2 font whose Private DICT declares local
+// subroutines. The Subrs offset is relative to the Private DICT, not to the
+// start of the table, so resolving it from the wrong base reads an arbitrary
+// position: with this fixture that lands on a byte giving offSize 140 and the
+// table is rejected outright, and on other fonts it can present a count of
+// hundreds of millions, or an offSize of 0.
+//
+// Because NewFont discards the error from loadCff2, a font in that state loads
+// with no CFF2 outlines at all rather than failing, which is why this went
+// unnoticed: the only other CFF2 fixture, NotoSansCJKjp-VF.otf, declares no
+// local subroutines and so never reaches the code.
+func TestCFF2LocalSubrs(t *testing.T) {
+	b, err := td.Files.ReadFile("toys/CFF2-VF.otf")
+	tu.AssertNoErr(t, err)
+
+	ft, err := ot.NewLoader(bytes.NewReader(b))
+	tu.AssertNoErr(t, err)
+
+	table, err := ft.RawTable(ot.MustNewTag("CFF2"))
+	tu.AssertNoErr(t, err)
+
+	out, err := ParseCFF2(table)
+	tu.AssertNoErr(t, err)
+
+	// the fixture declares local subroutines; if it stops doing so this test
+	// no longer covers anything and should be pointed at another font
+	nSubrs := 0
+	for _, f := range out.fonts {
+		nSubrs += len(f.localSubrs)
+	}
+	tu.Assert(t, nSubrs != 0)
+
+	// every glyph must interpret, which is what actually exercises the subrs:
+	// a charstring calling callsubr with a wrongly located INDEX fails here
+	tu.Assert(t, len(out.Charstrings) != 0)
+	for i := range out.Charstrings {
+		_, _, err := out.LoadGlyph(uint16(i), nil)
+		tu.AssertNoErr(t, err)
+	}
+}
+
 // TestParseIndexContentBounds guards against a malformed INDEX header driving
 // a huge allocation. The CFF2 INDEX header parser does not validate offSize
 // (unlike CFF1), so a font can present offSize 0 — which zeroes the length

--- a/font/cff/parser_test.go
+++ b/font/cff/parser_test.go
@@ -4,6 +4,7 @@ package cff
 
 import (
 	"bytes"
+	"encoding/binary"
 	"encoding/json"
 	"reflect"
 	"testing"
@@ -195,6 +196,91 @@ func TestCFF2LocalSubrs(t *testing.T) {
 		_, _, err := out.LoadGlyph(uint16(i), nil)
 		tu.AssertNoErr(t, err)
 	}
+}
+
+// buildCFF2LocalSubrs assembles a minimal CFF2 table whose Private DICT
+// declares local subroutines.
+//
+// It is synthetic rather than a font file so the case can be pinned exactly:
+// the Subrs offset is placed so that resolving it from the start of the table,
+// rather than from the Private DICT, lands inside the Top DICT and yields a
+// byte that is not a legal offSize. Real fonts differ only in what the wrong
+// address happens to contain.
+func buildCFF2LocalSubrs() []byte {
+	be32 := func(v uint32) []byte { b := make([]byte, 4); binary.BigEndian.PutUint32(b, v); return b }
+	dictInt := func(v int32) []byte { return append([]byte{29}, be32(uint32(v))...) }
+
+	// a CFF2 INDEX: count uint32, offSize uint8, count+1 offsets, then data
+	index := func(items ...[]byte) []byte {
+		out := be32(uint32(len(items)))
+		if len(items) == 0 {
+			return out
+		}
+		out = append(out, 1) // offSize
+		off := byte(1)
+		offs := []byte{off}
+		for _, it := range items {
+			off += byte(len(it))
+			offs = append(offs, off)
+		}
+		out = append(out, offs...)
+		for _, it := range items {
+			out = append(out, it...)
+		}
+		return out
+	}
+
+	const headerSize = 5
+	const topDictLen = 6 + 7 // CharStrings, then FDArray
+	const privDictLen = 6    // Subrs
+	charStringsOff := headerSize + topDictLen
+	charStrings := index([]byte{0x0b}) // one glyph: return
+	fdArrayOff := charStringsOff + len(charStrings)
+
+	fontDict := func(privOff int) []byte {
+		fd := append(dictInt(privDictLen), dictInt(int32(privOff))...)
+		return append(fd, 18) // Private [size, offset]
+	}
+	// the Font DICT's length does not depend on the value, so the offsets
+	// stay put when it is filled in
+	privDictOff := fdArrayOff + len(index(fontDict(0)))
+	fdArray := index(fontDict(privDictOff))
+
+	// "The local subrs offset is relative to the beginning of the Private
+	// DICT data", so the INDEX sits immediately after it and the operand is
+	// the DICT's own length
+	privDict := append(dictInt(privDictLen), 19) // Subrs
+	localSubrs := index([]byte{0x0b, 0x0b}, []byte{0x0b, 0x0b, 0x0b})
+
+	out := []byte{2, 0, headerSize, 0, 0}
+	binary.BigEndian.PutUint16(out[3:], topDictLen)
+	top := append(dictInt(int32(charStringsOff)), 17)
+	top = append(top, dictInt(int32(fdArrayOff))...)
+	top = append(top, 12, 36)
+	out = append(out, top...)
+	out = append(out, charStrings...)
+	out = append(out, fdArray...)
+	out = append(out, privDict...)
+	return append(out, localSubrs...)
+}
+
+// TestCFF2LocalSubrsOffset pins that a Private DICT's Subrs operand is resolved
+// relative to the Private DICT and not to the start of the table.
+//
+// Reading it from the wrong base gives whatever happens to be at that address.
+// Here it is a byte inside the Top DICT that is not a legal offSize, so the
+// table is rejected; on the fonts that prompted this it was an offSize of 0 or
+// a count of tens of millions. Because NewFont discards the error from
+// loadCff2, the visible effect in all of those cases is a font that loads with
+// no CFF2 outlines at all.
+func TestCFF2LocalSubrsOffset(t *testing.T) {
+	out, err := ParseCFF2(buildCFF2LocalSubrs())
+	tu.AssertNoErr(t, err)
+
+	tu.Assert(t, len(out.fonts) == 1)
+	subrs := out.fonts[0].localSubrs
+	tu.Assert(t, len(subrs) == 2)
+	tu.Assert(t, len(subrs[0]) == 2 && len(subrs[1]) == 3)
 }
 
 // TestParseIndexContentBounds guards against a malformed INDEX header driving


### PR DESCRIPTION
The `Subrs` operand in a Private DICT is an offset *"relative to the beginning of the
Private DICT data"* (5176.CFF.pdf §15, CFF2 §10). `ParseCFF2` was treating it as an
offset from the start of the table, so any CFF2 font declaring local subroutines had its
Local Subrs INDEX read from an arbitrary position.

The CFF1 parser already handles this correctly, in `parsePrivateDict`:

```go
// "The local subrs offset is relative to the beginning of the Private DICT data"
if err = p.seek(offset + priv.subrsOffset); err != nil {
```

The CFF2 path omitted the base:

```go
-out.fonts[i].localSubrs, err = parseIndex2(src, int(pd.subrsOffset))
+subrsOffset := int(fd.privateDictOffset) + int(pd.subrsOffset)
+out.fonts[i].localSubrs, err = parseIndex2(src, subrsOffset)
```

### What the wrong position yields

Whatever happens to be at that address. On this repo's own `toys/CFF2-VF.otf` it is a
byte giving `offSize 140`, so the table is rejected. Of the three CFF2 fonts shipped with
macOS that declare local subroutines, two present counts of 28 and 58 million and fail the
length check, and `ZitherIndia.otf` presents `offSize 0` — which before #267 fell through
to `bigEndian(src[0:0])` and panicked with `"unreachable"`, and now errors.

For `ZitherIndia.otf` the arithmetic is easy to see: its Private DICT is at 1206785 with
size 161, and `Subrs` is 161 (the INDEX sits immediately after the DICT, as usual).

| | address | count | offSize |
|---|---|---|---|
| read as-is, `src[161]` | 161 | 2717909960 | **0** |
| relative to the Private DICT, `src[1206785+161]` | 1206946 | 17582 | 3 |

### Why it went unnoticed

Two reasons, both worth fixing separately at some point:

1. `NewFont` discards the error — `out.cff2, _ = loadCff2(...)` — so an affected font
   loads with **no CFF2 outlines** rather than failing.
2. No test reached the code. The only other CFF2 fixture,
   `common/NotoSansCJKjp-VF.otf`, has 18 font DICTs and **zero** local subroutines. And
   the existing user of `toys/CFF2-VF.otf` (`TestVar`) exercises `fvar` normalization
   only — it never asks for a glyph, so it passes while the font's outlines are absent.

### After

All four parse, and every glyph interprets:

| font | before | after |
|---|---|---|
| `toys/CFF2-VF.otf` | `invalid offSize 140` | 5 charstrings, 3 local subrs |
| `ZitherIndia.otf` | `invalid offSize 0` (panic before #267) | 5683 charstrings, 17582 local subrs |
| `ZitherMalayalam.otf` | `EOF: expected length 232001036` | 198 charstrings, 485 local subrs |
| `ZitherTamil.otf` | `EOF: expected length 28246451` | 647 charstrings, 770 local subrs |

`common/NotoSansCJKjp-VF.otf` is unaffected either way — it has no local subroutines.

### Test

`TestCFF2LocalSubrs` uses the existing `toys/CFF2-VF.otf`, so no new fixture is needed. It
asserts the font declares subroutines and that every glyph loads — the latter is what
actually exercises them, since a charstring reaching `callsubr` with a wrongly located
INDEX fails there. Without this change it fails with
`reading INDEX: invalid offSize 140`.

### Also included

A guard against a negative offset in `parseIndex2`. Its length check
(`if L := len(src); L < offset+5`) passes trivially for a negative offset, and
`src[offset:]` then panics. This is newly reachable now that the offset is the sum of two
values read from the font.

### Relation to #267

#267 added the `offSize` validation whose comment notes that *"The CFF2 INDEX header
parser does not validate it the way the CFF1 path does"*. This is the other half of that
story: the reason a perfectly valid font was presenting a bogus `offSize` in the first
place. #267 stopped the crash; this stops the misread that caused it.